### PR TITLE
feat: Implement Input component

### DIFF
--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -1,31 +1,12 @@
-import { forwardRef, InputHTMLAttributes, useId } from 'react';
-import { cva, type VariantProps } from 'class-variance-authority';
+import { InputHTMLAttributes, useId } from 'react';
 import { cn } from '@/utils/cn';
 
-const inputVariants = cva('px-4', {
-  variants: {
-    variant: {
-      default: 'border-2 border-violet-950 rounded-lg',
-    },
-    size: {
-      default: 'h-11 w-full text-base placeholder:text-eastbay-500 text-violet-950 ',
-    },
-  },
-  defaultVariants: {
-    variant: 'default',
-    size: 'default',
-  },
-});
-
-export interface InputProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>,
-    VariantProps<typeof inputVariants> {
-  asChild?: boolean;
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   placeholder: string;
   label?: string;
 }
 
-const Input = forwardRef<HTMLInputElement, InputProps>(({ className, variant, size, label, ...props }, ref) => {
+const Input = ({ className, label, ...props }: InputProps) => {
   const inputId = useId();
 
   return (
@@ -36,13 +17,14 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({ className, variant, si
       <input
         id={inputId}
         type="text"
-        className={cn(inputVariants({ variant, size, className }))}
-        ref={ref}
+        className={cn(
+          'h-11 w-full rounded-lg border-2 border-violet-950 px-4 text-base text-violet-950 placeholder:text-eastbay-500',
+          className,
+        )}
         {...props}
       />
     </>
   );
-});
-Input.displayName = 'Input';
+};
 
-export { Input, inputVariants };
+export { Input };

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { forwardRef, useId } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/cn';
 
@@ -25,8 +25,8 @@ export interface InputProps
   label?: string;
 }
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, variant, size, label, ...props }, ref) => {
-  const inputId = React.useId();
+const Input = forwardRef<HTMLInputElement, InputProps>(({ className, variant, size, label, ...props }, ref) => {
+  const inputId = useId();
 
   return (
     <>

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/utils/cn';
+
+const inputVariants = cva('px-4', {
+  variants: {
+    variant: {
+      default: 'border-2 border-violet-950 rounded-lg',
+    },
+    size: {
+      default: 'h-11 w-full text-base placeholder:text-eastbay-500 text-violet-950 ',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'default',
+  },
+});
+
+export interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>,
+    VariantProps<typeof inputVariants> {
+  asChild?: boolean;
+  placeholder: string;
+  label?: string;
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, variant, size, label, ...props }, ref) => {
+  const inputId = React.useId();
+
+  return (
+    <>
+      <label htmlFor={inputId} className="block text-violet-950">
+        {label}
+      </label>
+      <input
+        id={inputId}
+        type="text"
+        className={cn(inputVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    </>
+  );
+});
+Input.displayName = 'Input';
+
+export { Input, inputVariants };

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useId } from 'react';
+import { forwardRef, InputHTMLAttributes, useId } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/cn';
 
@@ -18,7 +18,7 @@ const inputVariants = cva('px-4', {
 });
 
 export interface InputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>,
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>,
     VariantProps<typeof inputVariants> {
   asChild?: boolean;
   placeholder: string;


### PR DESCRIPTION
## 📂 작업 내용

closes #12 

- [x]  Default 컴포넌트 구현
- [x]  props로 placeholder, label 받기

## 💡 자세한 설명

placeholder와 label을 props로 받는, 재사용 가능한 Input 컴포넌트 구현

## 📗 참고 자료 & 구현 결과 (선택)

![image](https://github.com/user-attachments/assets/480104a2-a13b-4ac8-9cae-7f65d941a3d6)
![image](https://github.com/user-attachments/assets/c2814ed9-5415-4002-b763-1f112245b8df)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
