### PR TITLE
feat: Implement resuable ChatBubble component

### DIFF
--- a/client/src/components/ui/ChatBubble.tsx
+++ b/client/src/components/ui/ChatBubble.tsx
@@ -27,28 +27,22 @@ export interface ChatBubbleProps extends React.HTMLAttributes<HTMLDivElement>, V
   nickname?: string;
 }
 
-const ChatBubble = React.forwardRef<HTMLDivElement, ChatBubbleProps>(({ className, variant, size, ...props }, ref) => {
-  const { nickname, content } = props;
-  return (
-    <div className="bg-violet-400">
-      {nickname && (
-        <div className="flex flex-col items-start gap-0.5">
-          <div className="text-xs text-eastbay-50">{nickname}</div>
+const ChatBubble = React.forwardRef<HTMLDivElement, ChatBubbleProps>(
+  ({ className, variant, size, content, nickname, ...props }, ref) => {
+    const isLeftAligned = Boolean(nickname);
+
+    return (
+      <div className="bg-violet-400">
+        <div className={cn('flex', isLeftAligned ? 'flex-col items-start gap-0.5' : 'justify-end')}>
+          {nickname && <div className="text-xs text-eastbay-50">{nickname}</div>}
           <span className={cn(chatBubbleVariants({ variant, size, className }))} ref={ref} {...props}>
             {content}
           </span>
         </div>
-      )}
-      {!nickname && (
-        <div className="flex justify-end">
-          <span className={cn(chatBubbleVariants({ variant, size, className }))} ref={ref} {...props}>
-            {content}
-          </span>
-        </div>
-      )}
-    </div>
-  );
-});
+      </div>
+    );
+  },
+);
 ChatBubble.displayName = 'ChatBubble';
 
 export { ChatBubble, chatBubbleVariants };

--- a/client/src/components/ui/ChatBubble.tsx
+++ b/client/src/components/ui/ChatBubble.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/cn';
 
 const chatBubbleVariants = cva(
-  'px-2.5 inline-flex items-center justify-center rounded-lg border-2 border-violet-950  text-violet-950',
+  'px-2.5 inline-flex items-center justify-center rounded-lg border-2 border-violet-950 text-violet-950',
   {
     variants: {
       variant: {
@@ -22,27 +22,33 @@ const chatBubbleVariants = cva(
 );
 
 export interface ChatBubbleProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof chatBubbleVariants> {
-  asChild?: boolean;
   content: string;
   nickname?: string;
 }
 
 const ChatBubble = React.forwardRef<HTMLDivElement, ChatBubbleProps>(
   ({ className, variant, size, content, nickname, ...props }, ref) => {
-    const isLeftAligned = Boolean(nickname);
+    const isOtherUser = Boolean(nickname);
 
     return (
-      <div className="bg-violet-400">
-        <div className={cn('flex', isLeftAligned ? 'flex-col items-start gap-0.5' : 'justify-end')}>
-          {nickname && <div className="text-xs text-eastbay-50">{nickname}</div>}
-          <span className={cn(chatBubbleVariants({ variant, size, className }))} ref={ref} {...props}>
-            {content}
+      <div
+        aria-label={isOtherUser ? `${nickname}님의 메시지: ${content}` : `내 메시지: ${content}`}
+        tabIndex={0}
+        className={cn('flex bg-violet-400', isOtherUser ? 'flex-col items-start gap-0.5' : 'justify-end')}
+      >
+        {isOtherUser && (
+          <span className="text-xs text-eastbay-50" aria-hidden="true">
+            {nickname}
           </span>
-        </div>
+        )}
+        <p className={cn(chatBubbleVariants({ variant, size, className }))} ref={ref} {...props}>
+          {content}
+        </p>
       </div>
     );
   },
 );
+
 ChatBubble.displayName = 'ChatBubble';
 
 export { ChatBubble, chatBubbleVariants };

--- a/client/src/components/ui/ChatBubble.tsx
+++ b/client/src/components/ui/ChatBubble.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/utils/cn';
+
+const chatBubbleVariants = cva(
+  'px-2.5 inline-flex items-center justify-center rounded-lg border-2 border-violet-950  text-violet-950',
+  {
+    variants: {
+      variant: {
+        default: 'bg-halfbaked-200',
+        secondary: 'bg-chartreuseyellow-200',
+      },
+      size: {
+        default: 'text-base min-h-8',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+export interface ChatBubbleProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof chatBubbleVariants> {
+  asChild?: boolean;
+  content: string;
+  nickname?: string;
+}
+
+const ChatBubble = React.forwardRef<HTMLDivElement, ChatBubbleProps>(({ className, variant, size, ...props }, ref) => {
+  const { nickname, content } = props;
+  return (
+    <div className="bg-violet-400">
+      {nickname && (
+        <div className="flex flex-col items-start gap-0.5">
+          <div className="text-xs text-eastbay-50">{nickname}</div>
+          <span className={cn(chatBubbleVariants({ variant, size, className }))} ref={ref} {...props}>
+            {content}
+          </span>
+        </div>
+      )}
+      {!nickname && (
+        <div className="flex justify-end">
+          <span className={cn(chatBubbleVariants({ variant, size, className }))} ref={ref} {...props}>
+            {content}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+});
+ChatBubble.displayName = 'ChatBubble';
+
+export { ChatBubble, chatBubbleVariants };

--- a/client/src/components/ui/ChatBubble.tsx
+++ b/client/src/components/ui/ChatBubble.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { forwardRef, HTMLAttributes } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/cn';
 
@@ -21,18 +21,19 @@ const chatBubbleVariants = cva(
   },
 );
 
-export interface ChatBubbleProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof chatBubbleVariants> {
+export interface ChatBubbleProps extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof chatBubbleVariants> {
   content: string;
   nickname?: string;
 }
 
-const ChatBubble = React.forwardRef<HTMLDivElement, ChatBubbleProps>(
+const ChatBubble = forwardRef<HTMLDivElement, ChatBubbleProps>(
   ({ className, variant, size, content, nickname, ...props }, ref) => {
     const isOtherUser = Boolean(nickname);
+    const ariaLabel = isOtherUser ? `${nickname}님의 메시지: ${content}` : `내 메시지: ${content}`;
 
     return (
       <div
-        aria-label={isOtherUser ? `${nickname}님의 메시지: ${content}` : `내 메시지: ${content}`}
+        aria-label={ariaLabel}
         tabIndex={0}
         className={cn('flex bg-violet-400', isOtherUser ? 'flex-col items-start gap-0.5' : 'justify-end')}
       >

--- a/client/src/components/ui/ChatBubble.tsx
+++ b/client/src/components/ui/ChatBubble.tsx
@@ -35,7 +35,7 @@ const ChatBubble = forwardRef<HTMLDivElement, ChatBubbleProps>(
       <div
         aria-label={ariaLabel}
         tabIndex={0}
-        className={cn('flex bg-violet-400', isOtherUser ? 'flex-col items-start gap-0.5' : 'justify-end')}
+        className={cn('flex', isOtherUser ? 'flex-col items-start gap-0.5' : 'justify-end')}
       >
         {isOtherUser && (
           <span className="text-xs text-eastbay-50" aria-hidden="true">

--- a/client/src/components/ui/ChatBubble.tsx
+++ b/client/src/components/ui/ChatBubble.tsx
@@ -1,22 +1,18 @@
-import { forwardRef, HTMLAttributes } from 'react';
+import { HTMLAttributes } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/cn';
 
 const chatBubbleVariants = cva(
-  'px-2.5 inline-flex items-center justify-center rounded-lg border-2 border-violet-950 text-violet-950',
+  'px-2.5 inline-flex items-center justify-center rounded-lg border-2 border-violet-950 text-violet-950 text-base min-h-8',
   {
     variants: {
       variant: {
         default: 'bg-halfbaked-200',
         secondary: 'bg-chartreuseyellow-200',
       },
-      size: {
-        default: 'text-base min-h-8',
-      },
     },
     defaultVariants: {
       variant: 'default',
-      size: 'default',
     },
   },
 );
@@ -26,30 +22,26 @@ export interface ChatBubbleProps extends HTMLAttributes<HTMLDivElement>, Variant
   nickname?: string;
 }
 
-const ChatBubble = forwardRef<HTMLDivElement, ChatBubbleProps>(
-  ({ className, variant, size, content, nickname, ...props }, ref) => {
-    const isOtherUser = Boolean(nickname);
-    const ariaLabel = isOtherUser ? `${nickname}님의 메시지: ${content}` : `내 메시지: ${content}`;
+const ChatBubble = ({ className, variant, content, nickname, ...props }: ChatBubbleProps) => {
+  const isOtherUser = Boolean(nickname);
+  const ariaLabel = isOtherUser ? `${nickname}님의 메시지: ${content}` : `내 메시지: ${content}`;
 
-    return (
-      <div
-        aria-label={ariaLabel}
-        tabIndex={0}
-        className={cn('flex', isOtherUser ? 'flex-col items-start gap-0.5' : 'justify-end')}
-      >
-        {isOtherUser && (
-          <span className="text-xs text-eastbay-50" aria-hidden="true">
-            {nickname}
-          </span>
-        )}
-        <p className={cn(chatBubbleVariants({ variant, size, className }))} ref={ref} {...props}>
-          {content}
-        </p>
-      </div>
-    );
-  },
-);
-
-ChatBubble.displayName = 'ChatBubble';
+  return (
+    <div
+      aria-label={ariaLabel}
+      tabIndex={0}
+      className={cn('flex', isOtherUser ? 'flex-col items-start gap-0.5' : 'justify-end')}
+    >
+      {isOtherUser && (
+        <span className="text-xs text-eastbay-50" aria-hidden="true">
+          {nickname}
+        </span>
+      )}
+      <p className={cn(chatBubbleVariants({ variant, className }))} {...props}>
+        {content}
+      </p>
+    </div>
+  );
+};
 
 export { ChatBubble, chatBubbleVariants };


### PR DESCRIPTION
## 📂 작업 내용

closes #13 

- [x] Default 컴포넌트 구현
- [x] Secondary 컴포넌트 구현
- [x] props로 variant, content, nickname 받기

## 💡 자세한 설명

채팅에 쓸 ChatBubble 컴포넌트를 구현했습니다. 

## 📗 참고 자료 & 구현 결과 (선택)

![image](https://github.com/user-attachments/assets/c1eed14c-b94b-427c-bbaa-48ddc42a96ce)

- 위의 이미지에서 닉네임이 흰색으로 보이지 않아 backgroundColor를 임의로 추가했습니다. 코드에서는 backgroundColor를 삭제한 상태입니다. 

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
