### PR TITLE
feat: Implement reusable Modal component 

### DIFF
--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, HTMLAttributes, PropsWithChildren } from 'react';
+import { forwardRef, HTMLAttributes, KeyboardEvent, PropsWithChildren } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Button } from './Button';
 import { cn } from '@/utils/cn';
@@ -6,8 +6,10 @@ import { cn } from '@/utils/cn';
 interface ModalProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>>, VariantProps<typeof modalVariants> {
   asChild?: boolean;
   title: string;
-  isConfirmButton?: boolean;
+  haveConfirmButton?: boolean;
   handleConfirm?: () => void;
+  canManualClose?: boolean;
+  closeModal: () => void;
 }
 
 const modalVariants = cva('relative overflow-hidden flex-col justify-center rounded-xl w-full h-auto', {
@@ -22,16 +24,32 @@ const modalVariants = cva('relative overflow-hidden flex-col justify-center roun
 });
 
 const Modal = forwardRef<HTMLDivElement, ModalProps>(
-  ({ className, variant, isConfirmButton, title, children, ...props }, ref) => {
+  ({ className, variant, haveConfirmButton, closeModal, canManualClose, title, children, ...props }, ref) => {
+    const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') closeModal();
+    };
+
     return (
-      <div className="fixed left-0 top-0 flex h-full w-full items-center justify-center overflow-y-auto bg-violet-950 bg-opacity-50">
-        <div className={cn(modalVariants({ variant, className }))} ref={ref} {...props}>
+      <div
+        className="fixed left-0 top-0 flex h-full w-full items-center justify-center overflow-y-auto bg-violet-950 bg-opacity-50"
+        onClick={canManualClose ? closeModal : undefined}
+        onKeyDown={handleKeyDown}
+        tabIndex={0}
+      >
+        <div
+          className={cn(modalVariants({ variant, className }))}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={handleKeyDown}
+          tabIndex={0}
+          ref={ref}
+          {...props}
+        >
           <div className="g-auto flex min-h-16 items-center justify-center border-b-2 border-violet-950 bg-violet-500 px-3 py-3">
             <h2 className="translate-y-1 text-4xl text-stroke-md">{title}</h2>
           </div>
           <div className="flex h-full flex-col items-center justify-center gap-6 px-3 py-6">
             {children}
-            {isConfirmButton && <Button className="max-w-80">OK</Button>}
+            {haveConfirmButton && <Button className="max-w-80">OK</Button>}
           </div>
         </div>
       </div>

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -1,0 +1,44 @@
+import { forwardRef, HTMLAttributes, PropsWithChildren } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Button } from './Button';
+import { cn } from '@/utils/cn';
+
+interface ModalProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>>, VariantProps<typeof modalVariants> {
+  asChild?: boolean;
+  title: string;
+  isConfirmButton?: boolean;
+  handleConfirm?: () => void;
+}
+
+const modalVariants = cva('relative overflow-hidden flex-col justify-center rounded-xl w-full h-auto', {
+  variants: {
+    variant: {
+      primary: 'bg-violet-100 border-2 border-violet-950',
+    },
+  },
+  defaultVariants: {
+    variant: 'primary',
+  },
+});
+
+const Modal = forwardRef<HTMLDivElement, ModalProps>(
+  ({ className, variant, isConfirmButton, title, children, ...props }, ref) => {
+    return (
+      <div className="fixed left-0 top-0 flex h-full w-full items-center justify-center overflow-y-auto bg-violet-950 bg-opacity-50">
+        <div className={cn(modalVariants({ variant, className }))} ref={ref} {...props}>
+          <div className="g-auto flex min-h-16 items-center justify-center border-b-2 border-violet-950 bg-violet-500 px-3 py-3">
+            <h2 className="translate-y-1 text-4xl text-stroke-md">{title}</h2>
+          </div>
+          <div className="flex h-full flex-col items-center justify-center gap-6 px-3 py-6">
+            {children}
+            {isConfirmButton && <Button className="max-w-80">OK</Button>}
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+Modal.displayName = 'Modal';
+
+export { Modal, modalVariants };

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -1,62 +1,62 @@
-import { forwardRef, HTMLAttributes, KeyboardEvent, PropsWithChildren } from 'react';
-import { cva, type VariantProps } from 'class-variance-authority';
-import { Button } from './Button';
+import { HTMLAttributes, KeyboardEvent, PropsWithChildren } from 'react';
 import { cn } from '@/utils/cn';
 
-interface ModalProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>>, VariantProps<typeof modalVariants> {
-  asChild?: boolean;
+interface ModalProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
   title: string;
-  haveConfirmButton?: boolean;
-  handleConfirm?: () => void;
   canManualClose?: boolean;
   closeModal: () => void;
+  isModalOpened: boolean;
+  handleKeyDown?: (e: KeyboardEvent) => void;
 }
 
-const modalVariants = cva('relative overflow-hidden flex-col justify-center rounded-xl w-full h-auto', {
-  variants: {
-    variant: {
-      primary: 'bg-violet-100 border-2 border-violet-950',
-    },
-  },
-  defaultVariants: {
-    variant: 'primary',
-  },
-});
-
-const Modal = forwardRef<HTMLDivElement, ModalProps>(
-  ({ className, variant, haveConfirmButton, closeModal, canManualClose, title, children, ...props }, ref) => {
-    const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-      if (e.key === 'Escape') closeModal();
-    };
-
-    return (
+const Modal = ({
+  className,
+  handleKeyDown,
+  closeModal,
+  isModalOpened,
+  canManualClose,
+  title,
+  children,
+  ...props
+}: ModalProps) => {
+  return (
+    <div
+      className={cn(
+        'fixed left-0 top-0 flex h-full w-full items-center justify-center',
+        isModalOpened ? 'pointer-events-auto' : 'pointer-events-none',
+      )}
+      onClick={canManualClose ? closeModal : undefined}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+    >
       <div
-        className="fixed left-0 top-0 flex h-full w-full items-center justify-center overflow-y-auto bg-violet-950 bg-opacity-50"
-        onClick={canManualClose ? closeModal : undefined}
+        className={cn(
+          'absolute left-0 top-0 h-full w-full bg-violet-950',
+          isModalOpened ? 'opacity-50' : 'opacity-0',
+          'transition-opacity duration-300 ease-in-out',
+        )}
+      />
+
+      <div
+        className={cn(
+          isModalOpened ? 'opacity-100' : 'opacity-0',
+          'relative h-auto w-full flex-col justify-center overflow-hidden rounded-xl border-2 border-violet-950 bg-violet-100 transition-opacity duration-300 ease-in-out',
+          className,
+        )}
+        onClick={(e) => e.stopPropagation()}
         onKeyDown={handleKeyDown}
         tabIndex={0}
+        {...props}
       >
-        <div
-          className={cn(modalVariants({ variant, className }))}
-          onClick={(e) => e.stopPropagation()}
-          onKeyDown={handleKeyDown}
-          tabIndex={0}
-          ref={ref}
-          {...props}
-        >
-          <div className="g-auto flex min-h-16 items-center justify-center border-b-2 border-violet-950 bg-violet-500 px-3 py-3">
-            <h2 className="translate-y-1 text-4xl text-stroke-md">{title}</h2>
-          </div>
-          <div className="flex h-full flex-col items-center justify-center gap-6 px-3 py-6">
-            {children}
-            {haveConfirmButton && <Button className="max-w-80">OK</Button>}
-          </div>
+        <div className="g-auto flex min-h-16 items-center justify-center border-b-2 border-violet-950 bg-violet-500 px-3 py-3">
+          <h2 className="translate-y-1 text-4xl text-stroke-md">{title}</h2>
         </div>
+        <div className="p-5">{children}</div>
       </div>
-    );
-  },
-);
+    </div>
+  );
+};
 
 Modal.displayName = 'Modal';
 
-export { Modal, modalVariants };
+export { Modal };


### PR DESCRIPTION
## 📂 작업 내용

closes #7 

- [x] 작업 내용
- [x]  Default 컴포넌트 퍼블리싱
- [x]  Props로 title, canManualClose, closeModal, isModalOpened, handleKeyDown, content 받기
- [x]  라운드 종료 모달일 경우와 일반 모달일 경우를 고려해야함
- [x] 모달 애니메이션 구현 

## 💡 자세한 설명

모달 컴포넌트 구현했습니다.
props로는 nessasary로 `title`, `closeModal`, `isModalOpened` 받고 optional로 `canManualClose`, `handleKeyDown`, `children` 를 받습니다. 

width는 모달을 사용할 때 직접 지정해야합니다. 

## 📗 참고 자료 & 구현 결과 (선택)

![dimed](https://github.com/user-attachments/assets/3c2ae006-62ca-448a-83c8-1e34412ee8b7)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
