### PR TITLE
feat: Implement reusable Dropdown component

### DIFF
--- a/client/src/assets/arrow.svg
+++ b/client/src/assets/arrow.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  fill="none"
+  viewBox="0 0 24 24"
+  stroke="currentColor"
+>
+  <path
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    d="M19 9l-7 7-7-7"
+  />
+</svg>

--- a/client/src/components/ui/Dropdown.tsx
+++ b/client/src/components/ui/Dropdown.tsx
@@ -22,7 +22,7 @@ const Dropdown = ({ options, handleChange, selectedValue, className }: DropdownP
       {/* 선택한 value */}
       <button
         onClick={toggleDropdown}
-        className="flex w-full items-center justify-between rounded-lg border-2 border-violet-950 p-2 text-2xl"
+        className="flex w-full items-center justify-between rounded-lg border-2 border-violet-950 px-2 text-2xl"
       >
         <span className="w-full text-center">{selectedValue}</span>
         <img

--- a/client/src/components/ui/Dropdown.tsx
+++ b/client/src/components/ui/Dropdown.tsx
@@ -13,12 +13,12 @@ export interface DropdownProps extends SelectHTMLAttributes<HTMLSelectElement> {
 }
 
 const Dropdown = ({ options, handleChange, selectedValue, className }: DropdownProps) => {
-  const { isOpen, toggleDropdown, handleOptionClick } = useDropdown({
+  const { isOpen, toggleDropdown, handleOptionClick, dropdownRef } = useDropdown({
     handleChange,
   });
 
   return (
-    <div className={cn('relative bg-eastbay-50', className)}>
+    <div className={cn('relative bg-eastbay-50', className)} ref={dropdownRef}>
       {/* 선택한 value */}
       <button
         onClick={toggleDropdown}

--- a/client/src/components/ui/Dropdown.tsx
+++ b/client/src/components/ui/Dropdown.tsx
@@ -1,5 +1,6 @@
-import { SelectHTMLAttributes, useState } from 'react';
+import { SelectHTMLAttributes } from 'react';
 import ArrowDownIcon from '@/assets/arrow.svg';
+import { useDropdown } from '@/hooks/useDropdown';
 import { cn } from '@/utils/cn';
 
 export interface DropdownProps extends SelectHTMLAttributes<HTMLSelectElement> {
@@ -7,19 +8,14 @@ export interface DropdownProps extends SelectHTMLAttributes<HTMLSelectElement> {
     id: number;
     value: string;
   }[];
-  dropdownId: string;
+  handleChange: (value: string) => void;
+  selectedValue: string;
 }
 
-const Dropdown = ({ options, className }: DropdownProps) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<string>(options[0].value);
-
-  const toggleDropdown = () => setIsOpen((prev) => !prev);
-
-  const handleOptionClick = (value: string) => {
-    setSelectedOption(value);
-    setIsOpen(false);
-  };
+const Dropdown = ({ options, handleChange, selectedValue, className }: DropdownProps) => {
+  const { isOpen, toggleDropdown, handleOptionClick } = useDropdown({
+    handleChange,
+  });
 
   return (
     <div className={cn('relative bg-eastbay-50', className)}>
@@ -28,7 +24,7 @@ const Dropdown = ({ options, className }: DropdownProps) => {
         onClick={toggleDropdown}
         className="flex w-full items-center justify-between rounded-lg border-2 border-violet-950 p-2 text-2xl"
       >
-        <span className="w-full text-center">{selectedOption}</span>
+        <span className="w-full text-center">{selectedValue}</span>
         <img
           src={ArrowDownIcon}
           alt="드롭다운 메뉴 토글버튼"

--- a/client/src/components/ui/Dropdown.tsx
+++ b/client/src/components/ui/Dropdown.tsx
@@ -1,0 +1,62 @@
+import { SelectHTMLAttributes, useState } from 'react';
+import ArrowDownIcon from '@/assets/arrow.svg';
+import { cn } from '@/utils/cn';
+
+export interface DropdownProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  options: {
+    id: number;
+    value: string;
+  }[];
+  dropdownId: string;
+}
+
+const Dropdown = ({ options, className }: DropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedOption, setSelectedOption] = useState<string>(options[0].value);
+
+  const toggleDropdown = () => setIsOpen((prev) => !prev);
+
+  const handleOptionClick = (value: string) => {
+    setSelectedOption(value);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className={cn('relative bg-eastbay-50', className)}>
+      {/* 선택한 value */}
+      <button
+        onClick={toggleDropdown}
+        className="flex w-full items-center justify-between rounded-lg border-2 border-violet-950 p-2 text-2xl"
+      >
+        <span className="w-full text-center">{selectedOption}</span>
+        <img
+          src={ArrowDownIcon}
+          alt="드롭다운 메뉴 토글버튼"
+          className={cn('h-5 w-5 transition-transform', isOpen && 'rotate-180')}
+        />
+      </button>
+
+      {/* 드롭다운 메뉴 */}
+      <div
+        className={cn(
+          'absolute left-0 w-full rounded-lg bg-eastbay-50 shadow-lg transition-opacity ease-in-out',
+          isOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
+        )}
+      >
+        <div className="overflow-hidden rounded-lg">
+          {options.map((option) => (
+            <button
+              key={option.id}
+              onClick={() => handleOptionClick(option.value)}
+              className={cn('w-full p-2 text-center text-xl hover:bg-violet-100 focus:bg-violet-200')}
+            >
+              {option.value}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/client/src/components/ui/Dropdown.tsx
+++ b/client/src/components/ui/Dropdown.tsx
@@ -19,7 +19,6 @@ const Dropdown = ({ options, handleChange, selectedValue, className }: DropdownP
 
   return (
     <div className={cn('relative bg-eastbay-50', className)} ref={dropdownRef}>
-      {/* 선택한 value */}
       <button
         onClick={toggleDropdown}
         className="flex h-full w-full items-center justify-between rounded-lg border-2 border-violet-950 px-2 text-2xl"
@@ -28,15 +27,15 @@ const Dropdown = ({ options, handleChange, selectedValue, className }: DropdownP
         <img
           src={ArrowDownIcon}
           alt="드롭다운 메뉴 토글버튼"
-          className={cn('h-5 w-5 transition-transform', isOpen && 'rotate-180')}
+          className={cn('h-5 w-5 transition-transform duration-200', isOpen && 'rotate-180')}
         />
       </button>
 
-      {/* 드롭다운 메뉴 */}
       <div
         className={cn(
-          'absolute left-0 w-full rounded-lg bg-eastbay-50 shadow-lg transition-opacity ease-in-out',
-          isOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
+          'absolute left-0 w-full rounded-lg bg-eastbay-50 shadow-lg',
+          'origin-top transform transition-all duration-200',
+          !isOpen && 'invisible scale-y-0',
         )}
       >
         <div className="overflow-hidden rounded-lg">

--- a/client/src/components/ui/Dropdown.tsx
+++ b/client/src/components/ui/Dropdown.tsx
@@ -22,7 +22,7 @@ const Dropdown = ({ options, handleChange, selectedValue, className }: DropdownP
       {/* 선택한 value */}
       <button
         onClick={toggleDropdown}
-        className="flex w-full items-center justify-between rounded-lg border-2 border-violet-950 px-2 text-2xl"
+        className="flex h-full w-full items-center justify-between rounded-lg border-2 border-violet-950 px-2 text-2xl"
       >
         <span className="w-full text-center">{selectedValue}</span>
         <img

--- a/client/src/hooks/useDropdown.ts
+++ b/client/src/hooks/useDropdown.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+interface UseDropdown {
+  handleChange: (value: string) => void;
+}
+
+export const useDropdown = ({ handleChange }: UseDropdown) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleDropdown = () => setIsOpen((prev) => !prev);
+
+  const handleOptionClick = (value: string) => {
+    setIsOpen(false);
+    handleChange(value);
+  };
+
+  return {
+    isOpen,
+    toggleDropdown,
+    handleOptionClick,
+  };
+};

--- a/client/src/hooks/useDropdown.ts
+++ b/client/src/hooks/useDropdown.ts
@@ -1,8 +1,53 @@
 import { useState } from 'react';
 
+/**
+ * `useDropdown` 훅에 전달할 옵션 객체의 인터페이스입니다.
+ */
 interface UseDropdown {
+  /**
+   * 선택된 값을 처리하는 콜백 함수입니다.
+   *
+   * @param value - 선택된 값 입니다.
+   */
   handleChange: (value: string) => void;
 }
+
+/**
+ * 드롭다운의 상태를 관리하는 커스텀 훅입니다.
+ *
+ * @param handleChange - 옵션이 선택되었을 때 호출되는 함수입니다.
+ *                       선택된 값을 인자로 받습니다.
+ *
+ * @returns 다음과 같은 속성을 가진 객체를 반환합니다:
+ * - `isOpen`: 드롭다운이 열려있는지 닫혀있는지 나타내는 불리언 값입니다.
+ * - `toggleDropdown`: 드롭다운의 열림/닫힘 상태를 토글하는 함수입니다.
+ * - `handleOptionClick`: 드롭다운 옵션이 선택되었을 때 호출되는 함수입니다.
+ * 
+ * @example 
+ * const { isOpen, toggleDropdown, handleOptionClick } = useDropdown({
+    handleChange,
+  });
+
+  return (
+    <>
+      <button
+        onClick={toggleDropdown}
+      >
+        {isOpen ? '드롭다운 닫기' : '드롭다운 열기'}
+      </button>
+
+      {isOpen && options.map((option) => (
+        <button
+          key={option.id}
+          onClick={() => handleOptionClick(option.value)}
+        >
+          {option.value}
+        </button>
+      ))}
+    </>
+  );
+ * @category Hooks
+ */
 
 export const useDropdown = ({ handleChange }: UseDropdown) => {
   const [isOpen, setIsOpen] = useState(false);

--- a/client/src/hooks/useDropdown.ts
+++ b/client/src/hooks/useDropdown.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 /**
  * `useDropdown` 훅에 전달할 옵션 객체의 인터페이스입니다.
@@ -22,6 +22,7 @@ interface UseDropdown {
  * - `isOpen`: 드롭다운이 열려있는지 닫혀있는지 나타내는 불리언 값입니다.
  * - `toggleDropdown`: 드롭다운의 열림/닫힘 상태를 토글하는 함수입니다.
  * - `handleOptionClick`: 드롭다운 옵션이 선택되었을 때 호출되는 함수입니다.
+ * - `dropdownRef`: 드롭다운 컴포넌트의 DOM 요소를 참조하는 React Ref입니다. 바깥 영역 클릭 감지에 사용됩니다.
  * 
  * @example 
  * const { isOpen, toggleDropdown, handleOptionClick } = useDropdown({
@@ -51,6 +52,7 @@ interface UseDropdown {
 
 export const useDropdown = ({ handleChange }: UseDropdown) => {
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const toggleDropdown = () => setIsOpen((prev) => !prev);
 
@@ -59,9 +61,23 @@ export const useDropdown = ({ handleChange }: UseDropdown) => {
     handleChange(value);
   };
 
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
   return {
     isOpen,
     toggleDropdown,
     handleOptionClick,
+    dropdownRef,
   };
 };


### PR DESCRIPTION
## 📂 작업 내용

closes #29 

- [x] dropdown 커스텀
- [x] 선택된값, 선택된 값을 변경하는 함수를 props로 받는다.
- [x] 드롭다운 메뉴들을 props로 받는다.
- [x] dropdown 상태를 관리하는 useDropdown hook
- [x] useDropdown typedoc 작성

## 💡 자세한 설명

dropdown 공통 컴포넌트를 제작하였습니다.
useDropdown 으로 dropdown로직을 빼서 headless로 만들었습니다.
useDropdown에 대한 typedoc 작성하였습니다. 

## 📗 참고 자료 & 구현 결과 (선택)

![dropdown](https://github.com/user-attachments/assets/f65c4924-714a-48cb-be49-0859253b997b)

## 📢 리뷰 요구 사항 (선택)

select, option 같이 시맨틱 태그를 사용했다가 커스텀이 쉽지 않아서 시맨틱하지 못한 태그를 사용했습니다. 🥹
추후 리팩토링하겠습니다. 

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
