### PR TITLE
feat: Implement Setting component 

### DIFF
--- a/client/src/components/setting/Setting.tsx
+++ b/client/src/components/setting/Setting.tsx
@@ -1,0 +1,71 @@
+import { HTMLAttributes, useState } from 'react';
+import Dropdown from '../ui/Dropdown';
+import { SETTING_ITEMS } from '@/constants/setting';
+import { SettingOption, SettingKey, SettingValues } from '@/types/setting.types';
+import { cn } from '@/utils/cn';
+
+interface SettingProps extends HTMLAttributes<HTMLDivElement> {
+  roundCount?: number;
+  playerCount?: number;
+  timeLimit?: number;
+  type: 'host' | 'participant';
+}
+
+const Setting = ({ className, roundCount = 4, playerCount = 4, timeLimit = 30, type, ...props }: SettingProps) => {
+  const [selectedValues, setSelectedValues] = useState<SettingValues>({
+    roundCount,
+    playerCount,
+    timeLimit,
+  });
+
+  const handleChange = (key: SettingKey) => (value: string) => {
+    setSelectedValues((prev) => ({
+      ...prev,
+      [key]: Number(value),
+    }));
+  };
+
+  const convertToString = (options: SettingOption[]) =>
+    options.map((option) => ({
+      ...option,
+      value: option.value.toString(),
+    }));
+
+  return (
+    <section
+      className={cn(
+        'flex flex-col overflow-hidden border-y-2 border-violet-950 sm:rounded-xl sm:border-x-2',
+        className,
+      )}
+      {...props}
+    >
+      {/* Setting title */}
+      <div className="flex min-h-[3.375rem] w-full items-center justify-center border-b-2 border-violet-950 bg-violet-500 p-3 sm:min-h-16">
+        <h2 className="text-2xl text-white text-stroke-md sm:translate-y-1 sm:text-4xl">Setting</h2>
+      </div>
+
+      {/* Setting content */}
+      <div className="flex min-h-[16.125rem] items-center justify-center bg-violet-200 sm:min-h-[18.56rem] sm:px-6">
+        <div className="flex min-h-[13.8rem] w-full flex-col items-center justify-center gap-6 border-y-2 border-violet-950 bg-violet-50 p-4 text-2xl sm:rounded-[0.625rem] sm:border-x-2">
+          {SETTING_ITEMS.map(({ label, key, options }) => (
+            <div key={label} className="flex w-full max-w-[90%] items-center justify-between sm:max-w-[70%]">
+              <span>{label}</span>
+              {type === 'participant' ? (
+                <span>{selectedValues[key]}</span>
+              ) : (
+                <Dropdown
+                  options={convertToString(options)}
+                  selectedValue={selectedValues[key].toString()}
+                  handleChange={handleChange(key)}
+                  className="w-[30%] min-w-[4.25rem] sm:min-w-28"
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export { Setting };

--- a/client/src/components/setting/Setting.tsx
+++ b/client/src/components/setting/Setting.tsx
@@ -48,7 +48,7 @@ const Setting = ({ className, roundCount = 4, playerCount = 4, timeLimit = 30, t
       <div className="flex min-h-[16.125rem] items-center justify-center bg-violet-200 sm:min-h-[18.56rem] sm:px-6">
         <div className="flex min-h-[13.8rem] w-full flex-col items-center justify-center gap-6 border-y-2 border-violet-950 bg-violet-50 p-4 text-2xl sm:rounded-[0.625rem] sm:border-x-2">
           {SETTING_ITEMS.map(({ label, key, options }) => (
-            <div key={label} className="flex w-full max-w-[15.75rem] items-center justify-between sm:max-w-[70%]">
+            <div key={label} className="flex w-full max-w-80 items-center justify-between sm:max-w-[70%]">
               <span>{label}</span>
               {type === 'participant' ? (
                 <span>{selectedValues[key]}</span>

--- a/client/src/components/setting/Setting.tsx
+++ b/client/src/components/setting/Setting.tsx
@@ -48,7 +48,7 @@ const Setting = ({ className, roundCount = 4, playerCount = 4, timeLimit = 30, t
       <div className="flex min-h-[16.125rem] items-center justify-center bg-violet-200 sm:min-h-[18.56rem] sm:px-6">
         <div className="flex min-h-[13.8rem] w-full flex-col items-center justify-center gap-6 border-y-2 border-violet-950 bg-violet-50 p-4 text-2xl sm:rounded-[0.625rem] sm:border-x-2">
           {SETTING_ITEMS.map(({ label, key, options }) => (
-            <div key={label} className="flex w-full max-w-[90%] items-center justify-between sm:max-w-[70%]">
+            <div key={label} className="flex w-full max-w-[15.75rem] items-center justify-between sm:max-w-[70%]">
               <span>{label}</span>
               {type === 'participant' ? (
                 <span>{selectedValues[key]}</span>

--- a/client/src/components/ui/Dropdown.tsx
+++ b/client/src/components/ui/Dropdown.tsx
@@ -1,9 +1,9 @@
-import { SelectHTMLAttributes } from 'react';
+import { HTMLAttributes } from 'react';
 import ArrowDownIcon from '@/assets/arrow.svg';
 import { useDropdown } from '@/hooks/useDropdown';
 import { cn } from '@/utils/cn';
 
-export interface DropdownProps extends SelectHTMLAttributes<HTMLSelectElement> {
+export interface DropdownProps extends HTMLAttributes<HTMLDivElement> {
   options: {
     id: number;
     value: string;
@@ -12,13 +12,13 @@ export interface DropdownProps extends SelectHTMLAttributes<HTMLSelectElement> {
   selectedValue: string;
 }
 
-const Dropdown = ({ options, handleChange, selectedValue, className }: DropdownProps) => {
+const Dropdown = ({ options, handleChange, selectedValue, className, ...props }: DropdownProps) => {
   const { isOpen, toggleDropdown, handleOptionClick, dropdownRef } = useDropdown({
     handleChange,
   });
 
   return (
-    <div className={cn('relative bg-eastbay-50', className)} ref={dropdownRef}>
+    <div className={cn('relative rounded-lg bg-eastbay-50', className)} ref={dropdownRef} {...props}>
       <button
         onClick={toggleDropdown}
         className="flex h-full w-full items-center justify-between rounded-lg border-2 border-violet-950 px-2 text-2xl"
@@ -33,7 +33,7 @@ const Dropdown = ({ options, handleChange, selectedValue, className }: DropdownP
 
       <div
         className={cn(
-          'absolute left-0 w-full rounded-lg bg-eastbay-50 shadow-lg',
+          'absolute left-0 z-10 w-full rounded-lg bg-eastbay-50 shadow-lg',
           'origin-top transform transition-all duration-200',
           !isOpen && 'invisible scale-y-0',
         )}
@@ -43,7 +43,9 @@ const Dropdown = ({ options, handleChange, selectedValue, className }: DropdownP
             <button
               key={option.id}
               onClick={() => handleOptionClick(option.value)}
-              className={cn('w-full p-2 text-center text-xl hover:bg-violet-100 focus:bg-violet-200')}
+              className={cn(
+                'w-full p-2 text-center text-xl transition-colors duration-200 ease-in-out hover:bg-violet-100 focus:bg-violet-200',
+              )}
             >
               {option.value}
             </button>

--- a/client/src/constants/setting.ts
+++ b/client/src/constants/setting.ts
@@ -1,0 +1,24 @@
+import { SettingOption, Setting, SettingKey } from '@/types/setting.types';
+
+export const OPTIONS: Record<SettingKey, SettingOption[]> = {
+  roundCount: [
+    { id: 1, value: 4 },
+    { id: 2, value: 6 },
+    { id: 3, value: 8 },
+  ],
+  playerCount: [
+    { id: 1, value: 4 },
+    { id: 2, value: 5 },
+    { id: 3, value: 6 },
+  ],
+  timeLimit: [
+    { id: 1, value: 15 },
+    { id: 2, value: 30 },
+  ],
+} as const;
+
+export const SETTING_ITEMS: Setting[] = [
+  { label: '라운드 수', key: 'roundCount', options: OPTIONS.roundCount },
+  { label: '플레이어 수', key: 'playerCount', options: OPTIONS.playerCount },
+  { label: '제한 시간', key: 'timeLimit', options: OPTIONS.timeLimit },
+] as const;

--- a/client/src/types/setting.types.ts
+++ b/client/src/types/setting.types.ts
@@ -1,0 +1,16 @@
+export type Setting = {
+  label: string;
+  key: SettingKey;
+  options: SettingOption[];
+};
+
+export type SettingKey = 'roundCount' | 'playerCount' | 'timeLimit';
+
+export type SettingValues = {
+  [K in SettingKey]: number;
+};
+
+export type SettingOption = {
+  id: number;
+  value: number;
+};


### PR DESCRIPTION
## 📂 작업 내용

closes #6 

- [x] props로 '방장' 또는 '일반 팀원'을 받는다.
- [x] props로 라운드 수, 플레이어 수, 제한 시간을 받는다. 
- [x] type 파일, constant 파일 분리 


## 💡 자세한 설명

- props로 'host'(방장) 과 'participant'(참가자) 를 받습니다. 
방장이면 dropdown 컴포넌트가 뜨고, 참가자이면 텍스트가 뜹니다. 

- 드롭다운에 들어가는 옵션 값은 constant/setting.ts 파일에 임의로 넣었습니다. 

## 📗 참고 자료 & 구현 결과 (선택)

- host

![host3](https://github.com/user-attachments/assets/1185defa-0015-436c-9f63-c80337021804)

- participant

![participant3](https://github.com/user-attachments/assets/49d14b40-bee3-4705-8e2b-f720392f57f2)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택) 

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
