### PR TITLE
feat: Add Storybook workflow 

### DIFF
--- a/.github/workflows/storybook-ci-cd.yml
+++ b/.github/workflows/storybook-ci-cd.yml
@@ -1,0 +1,49 @@
+name: Deploy Storybook Production 
+
+on:
+  push:
+    branches:
+      - main
+      - develop 
+    paths:
+      - client/**
+
+defaults:
+  run:
+    working-directory: ./client
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "pnpm"
+          cache-dependency-path: "./client/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build storybook
+        run: pnpm run build-storybook
+        
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./client/storybook-static
+					destination_dir: ${{ github.ref == 'refs/heads/main' && 'storybook' || 'storybook-develop' }} 

--- a/.github/workflows/storybook-preview-ci-cd.yml
+++ b/.github/workflows/storybook-preview-ci-cd.yml
@@ -51,7 +51,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./client/storybook-static
+          publish_dir: storybook-static
           destination_dir: storybook/preview/pr-${{ github.event.number }}
 
       - name: Comment Preview URL
@@ -77,7 +77,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./client/storybook-static
+          publish_dir: storybook-static
           destination_dir: storybook/preview/pr-${{ github.event.number }}
           keep_files: false
 

--- a/.github/workflows/storybook-preview-ci-cd.yml
+++ b/.github/workflows/storybook-preview-ci-cd.yml
@@ -55,47 +55,38 @@ jobs:
           destination_dir: storybook/preview-${{ github.event.number }}
           commit_message: "docs: deploy storybook-preview"
 
-      - name: Comment Preview URL
+      - name: Set Preview URL
+        run: echo "::notice::🚀 Preview: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/storybook/preview-${{ github.event.number }}"
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Delete preview directory
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git rm -rf storybook/preview-${{ github.event.number }}
+          git commit -m "docs: remove storybook preview for PR #${{ github.event.number }}"
+          git push origin gh-pages
+
+      - name: Comment Cleanup Notification
         uses: actions/github-script@v6
         with:
           script: |
-            const previewUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/storybook/preview-${context.issue.number}`
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `📚 Storybook preview deployed to: [${previewUrl}](${previewUrl})`
+              body: `🧹 Storybook preview for PR #${context.issue.number} has been removed.`
             })
-
-cleanup-preview:
-  if: github.event.action == 'closed'
-  runs-on: ubuntu-latest
-
-  permissions:
-    contents: write
-    pull-requests: write
-
-  steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        ref: gh-pages
-
-    - name: Delete preview directory
-      run: |
-        git config --global user.name 'github-actions[bot]'
-        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-        git rm -rf storybook/preview-${{ github.event.number }}
-        git commit -m "docs: remove storybook preview for PR #${{ github.event.number }}"
-        git push origin gh-pages
-
-    - name: Comment Cleanup Notification
-      uses: actions/github-script@v6
-      with:
-        script: |
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `🧹 Storybook preview for PR #${context.issue.number} has been removed.`
-          })

--- a/.github/workflows/storybook-preview-ci-cd.yml
+++ b/.github/workflows/storybook-preview-ci-cd.yml
@@ -20,13 +20,10 @@ defaults:
 jobs:
   deploy-preview:
     if: github.event.action != 'closed'
-
     runs-on: ubuntu-latest
-
     permissions:
       contents: write
       pull-requests: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,18 +55,21 @@ jobs:
           destination_dir: storybook/preview-${{ github.event.number }}
           commit_message: "docs: deploy storybook-preview"
 
-    environment:
-      name: Storybook Preview
-      url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/storybook/preview-${{ github.event.number }}
-      transient_environment: true
+      - name: Comment Preview URL
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const previewUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/storybook/preview-${context.issue.number}`
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `📚 Storybook preview deployed to: [Visit Storybook Preview](${previewUrl})`
+            })
 
   cleanup-preview:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        working-directory: .
 
     permissions:
       contents: write

--- a/.github/workflows/storybook-preview-ci-cd.yml
+++ b/.github/workflows/storybook-preview-ci-cd.yml
@@ -51,14 +51,15 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: storybook-static
-          destination_dir: storybook/preview/pr-${{ github.event.number }}
+          publish_dir: ./client/storybook-static
+          destination_dir: storybook/preview-${{ github.event.number }}
+          commit_message: "docs: deploy storybook-preview"
 
       - name: Comment Preview URL
         uses: actions/github-script@v6
         with:
           script: |
-            const previewUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/storybook/preview/pr-${context.issue.number}`
+            const previewUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/storybook/preview-${context.issue.number}`
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -66,28 +67,35 @@ jobs:
               body: `📚 Storybook preview deployed to: [${previewUrl}](${previewUrl})`
             })
 
-  cleanup-preview:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Delete preview from gh-pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: storybook-static
-          destination_dir: storybook/preview/pr-${{ github.event.number }}
-          keep_files: false
+cleanup-preview:
+  if: github.event.action == 'closed'
+  runs-on: ubuntu-latest
 
-      - name: Comment Cleanup Notification
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `🧹 Storybook preview for PR #${context.issue.number} has been removed.`
-            })
+  permissions:
+    contents: write
+    pull-requests: write
+
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: gh-pages
+
+    - name: Delete preview directory
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git rm -rf storybook/preview-${{ github.event.number }}
+        git commit -m "docs: remove storybook preview for PR #${{ github.event.number }}"
+        git push origin gh-pages
+
+    - name: Comment Cleanup Notification
+      uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `🧹 Storybook preview for PR #${context.issue.number} has been removed.`
+          })

--- a/.github/workflows/storybook-preview-ci-cd.yml
+++ b/.github/workflows/storybook-preview-ci-cd.yml
@@ -58,14 +58,10 @@ jobs:
           destination_dir: storybook/preview-${{ github.event.number }}
           commit_message: "docs: deploy storybook-preview"
 
-      - name: Set Preview URL
-        if: success()
-        id: deployment
-        run: echo "preview-url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/storybook/preview-${{ github.event.number }}" >> $GITHUB_OUTPUT
-
     environment:
       name: Storybook Preview
-      url: ${{steps.deployment.outputs.preview-url}}
+      url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/storybook/preview-${{ github.event.number }}
+      transient_environment: true
 
   cleanup-preview:
     if: github.event.action == 'closed'

--- a/.github/workflows/storybook-preview-ci-cd.yml
+++ b/.github/workflows/storybook-preview-ci-cd.yml
@@ -20,10 +20,13 @@ defaults:
 jobs:
   deploy-preview:
     if: github.event.action != 'closed'
+
     runs-on: ubuntu-latest
+
     permissions:
       contents: write
       pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,8 +59,13 @@ jobs:
           commit_message: "docs: deploy storybook-preview"
 
       - name: Set Preview URL
-        run: |
-          echo "🚀 Preview URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/storybook/preview-${{ github.event.number }}"
+        if: success()
+        id: deployment
+        run: echo "preview-url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/storybook/preview-${{ github.event.number }}" >> $GITHUB_OUTPUT
+
+    environment:
+      name: Storybook Preview
+      url: ${{steps.deployment.outputs.preview-url}}
 
   cleanup-preview:
     if: github.event.action == 'closed'

--- a/.github/workflows/storybook-preview-ci-cd.yml
+++ b/.github/workflows/storybook-preview-ci-cd.yml
@@ -75,6 +75,10 @@ jobs:
       contents: write
       pull-requests: write
 
+    defaults:
+      run:
+        working-directory: .
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -83,11 +87,13 @@ jobs:
 
       - name: Delete preview directory
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git rm -rf storybook/preview-${{ github.event.number }}
-          git commit -m "docs: remove storybook preview for PR #${{ github.event.number }}"
-          git push origin gh-pages
+          if [ -d "storybook/preview-${{ github.event.number }}" ]; then
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            git rm -rf "storybook/preview-${{ github.event.number }}"
+            git commit -m "docs: remove storybook preview for PR #${{ github.event.number }}"
+            git push origin gh-pages
+          fi
 
       - name: Comment Cleanup Notification
         uses: actions/github-script@v6

--- a/.github/workflows/storybook-preview-ci-cd.yml
+++ b/.github/workflows/storybook-preview-ci-cd.yml
@@ -56,7 +56,8 @@ jobs:
           commit_message: "docs: deploy storybook-preview"
 
       - name: Set Preview URL
-        run: echo "::notice::🚀 Preview: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/storybook/preview-${{ github.event.number }}"
+        run: |
+          echo "🚀 Preview URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/storybook/preview-${{ github.event.number }}"
 
   cleanup-preview:
     if: github.event.action == 'closed'

--- a/.github/workflows/storybook-preview-ci-cd.yml
+++ b/.github/workflows/storybook-preview-ci-cd.yml
@@ -1,0 +1,93 @@
+name: Deploy Storybook Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+    branches:
+      - main
+      - develop
+    paths:
+      - client/**
+
+defaults:
+  run:
+    working-directory: ./client
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "pnpm"
+          cache-dependency-path: "./client/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build storybook
+        run: pnpm run build-storybook
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./client/storybook-static
+          destination_dir: storybook/preview/pr-${{ github.event.number }}
+
+      - name: Comment Preview URL
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const previewUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/storybook/preview/pr-${context.issue.number}`
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `📚 Storybook preview deployed to: [${previewUrl}](${previewUrl})`
+            })
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Delete preview from gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./client/storybook-static
+          destination_dir: storybook/preview/pr-${{ github.event.number }}
+          keep_files: false
+
+      - name: Comment Cleanup Notification
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🧹 Storybook preview for PR #${context.issue.number} has been removed.`
+            })

--- a/.github/workflows/storybook-preview-ci-cd.yml
+++ b/.github/workflows/storybook-preview-ci-cd.yml
@@ -71,6 +71,10 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        working-directory: .
+
     permissions:
       contents: write
       pull-requests: write

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -64,7 +64,7 @@ const App = () => {
         <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">그림꾼</span>
       </Modal>
 
-      {/* storybook-preview test9 */}
+      {/* storybook-preview test10 */}
     </main>
   );
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -64,7 +64,7 @@ const App = () => {
         <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">그림꾼</span>
       </Modal>
 
-      {/* storybook-preview test2 */}
+      {/* storybook-preview test4 */}
     </main>
   );
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -64,7 +64,7 @@ const App = () => {
         <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">그림꾼</span>
       </Modal>
 
-      {/* storybook-preview test7 */}
+      {/* storybook-preview test8 */}
     </main>
   );
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -64,7 +64,7 @@ const App = () => {
         <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">그림꾼</span>
       </Modal>
 
-      {/* storybook-preview test5 */}
+      {/* storybook-preview test6 */}
     </main>
   );
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -64,7 +64,7 @@ const App = () => {
         <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">그림꾼</span>
       </Modal>
 
-      {/* storybook-preview test8 */}
+      {/* storybook-preview test9 */}
     </main>
   );
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -64,7 +64,7 @@ const App = () => {
         <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">그림꾼</span>
       </Modal>
 
-      {/* storybook-preview test6 */}
+      {/* storybook-preview test7 */}
     </main>
   );
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -63,6 +63,8 @@ const App = () => {
       <Modal title="역할 배정" isModalOpened={isModalOpened} className="w-80">
         <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">그림꾼</span>
       </Modal>
+
+      {/* storybook-preview test */}
     </main>
   );
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -64,7 +64,7 @@ const App = () => {
         <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">그림꾼</span>
       </Modal>
 
-      {/* storybook-preview test4 */}
+      {/* storybook-preview test5 */}
     </main>
   );
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -64,7 +64,7 @@ const App = () => {
         <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">그림꾼</span>
       </Modal>
 
-      {/* storybook-preview test */}
+      {/* storybook-preview test2 */}
     </main>
   );
 };

--- a/client/typedoc.json
+++ b/client/typedoc.json
@@ -5,5 +5,11 @@
   "favicon": "./public/favicon.ico",
   "plugin": ["typedoc-plugin-extras"],
   "entryPoints": ["src/utils/*.ts", "src/hooks/*.ts", "src/hooks/*.tsx"],
-  "exclude": ["**/node_modules/**", "**/dist/**"]
+  "exclude": ["**/node_modules/**", "**/dist/**"],
+  "basePath": "/web30-stop-troublepainter/",
+  "navigationLinks": {
+    "Documentation": "./",
+    "Storybook (Main)": "./storybook",
+    "Storybook (Develop)": "./storybook-develop"
+  }
 }


### PR DESCRIPTION
## 📂 작업 내용

closes #3 

 - [x] main, develop 브랜치에 push 이벤트 발생하면 배포한다.
 - [x] main, develop 브랜치에 PR 이벤트 발생하면 preview를 배포한다.
 - [x] PR이 닫히면 preview를 삭제한다.
 
## 💡 자세한 설명

- chromatic으로 배포하려했으나 네부캠 organization 권한 문제로 배포 불가능하여 github page로 배포하였습니다.

- main 브랜치, develop 브랜치에 push될 때 storybook 배포
   - main 브랜치일 때는 https://boostcampwm-2024.github.io/web30-stop-troublepainter/ `storybook` 경로에 배포
   - develop 브랜치일 때는 https://boostcampwm-2024.github.io/web30-stop-troublepainter/ `storybook-develop`  경로에 배포
   
- preview 배포
   - main 브랜치나 develop 브랜치에 PR을 생성, 수정하는 경우 preview를 생성한다.
    - 경로: [https://boostcampwm-2024.github.io/storybook/preview-${PR}](https://boostcampwm-2024.github.io/storybook/preview-$%7BPR%7D)
   - pr이 닫히면 preview는 삭제된다.
      - gh-pages 브랜치의 [https://boostcampwm-2024.github.io/storybook/preview-${PR}](https://boostcampwm-2024.github.io/storybook/preview-$%7BPR%7D) 폴더를 삭제한다.

## 📗 참고 자료 & 구현 결과 (선택)

![image](https://github.com/user-attachments/assets/c366b3bf-a385-468d-b30d-e68fd4c45b85)


## 📢 리뷰 요구 사항 (선택) 

## 🚩 후속 작업 (선택)

- comment로 할 경우, PR 생성 후 push 더 하면 그만큼의 comment 또 생성됨, 다른 방식 고려해보기
- deploy-preview하는 것에 30초 가량 소요됨, 최적화 방법 학습/적용 

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
