### PR TITLE
feat: Implement Main page & Implement transitions with pixel animations and hover effects

### DIFF
--- a/client/src/components/ui/Button.tsx
+++ b/client/src/components/ui/Button.tsx
@@ -7,7 +7,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        proimary: 'border-y-2 border-violet-950 bg-violet-500 hover:bg-violet-600 sm:border-2',
+        primary: 'border-y-2 border-violet-950 bg-violet-500 hover:bg-violet-600 sm:border-2',
         secondary: 'bg-eastbay-900 border-2 border-violet-950 hover:bg-eastbay-950',
         transperent: 'hover:brightness-95',
       },
@@ -17,7 +17,7 @@ const buttonVariants = cva(
       },
     },
     defaultVariants: {
-      variant: 'proimary',
+      variant: 'primary',
       size: 'text',
     },
   },

--- a/client/src/components/ui/Button.tsx
+++ b/client/src/components/ui/Button.tsx
@@ -3,16 +3,16 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/cn';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap ring-offset-background transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        primary: 'border-y-2 border-violet-950 bg-violet-500 hover:bg-violet-600 sm:border-2',
-        secondary: 'bg-eastbay-900 border-2 border-violet-950 hover:bg-eastbay-950',
+        primary: 'border-2 border-violet-950 bg-violet-500 hover:bg-violet-600',
+        secondary: 'border-2 border-violet-950 bg-eastbay-900 hover:bg-eastbay-950',
         transperent: 'hover:brightness-95',
       },
       size: {
-        text: 'h-11 w-full text-2xl font-medium text-stroke-md sm:h-14 sm:rounded-2xl',
+        text: 'h-14 w-full rounded-2xl text-2xl font-medium text-stroke-md',
         icon: 'h-10 w-10',
       },
     },

--- a/client/src/components/ui/PixelTransitionContainer.tsx
+++ b/client/src/components/ui/PixelTransitionContainer.tsx
@@ -69,7 +69,7 @@ const PixelTransitionContainer = ({
     <div
       className={cn(
         'relative overflow-hidden transition-colors duration-700',
-        isExiting ? 'bg-transparent' : 'bg-violet-950',
+        isExiting ? 'bg-violet-950' : 'bg-transparent',
         className,
       )}
       aria-busy={isExiting}

--- a/client/src/components/ui/PixelTransitionContainer.tsx
+++ b/client/src/components/ui/PixelTransitionContainer.tsx
@@ -16,11 +16,40 @@ const contentVariants = cva('transition-transform duration-1000', {
   },
 });
 
+const containerVariants = cva('relative overflow-hidden transition-colors duration-700', {
+  variants: {
+    colorTheme: {
+      violet: 'data-[exiting=true]:bg-violet-950',
+      eastbay: 'data-[exiting=true]:bg-eastbay-950',
+    },
+  },
+  defaultVariants: {
+    colorTheme: 'violet',
+  },
+});
+
+const pixelVariants = cva(
+  'aspect-square border bg-transparent transition-[transform,border-color,background-color] duration-600 border-transparent',
+  {
+    variants: {
+      colorTheme: {
+        violet: 'data-[exiting=true]:border-violet-800 data-[exiting=true]:bg-violet-500',
+        eastbay: 'data-[exiting=true]:border-eastbay-800 data-[exiting=true]:bg-eastbay-500',
+      },
+    },
+    defaultVariants: {
+      colorTheme: 'violet',
+    },
+  },
+);
+
 interface PixelTransitionProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
-  // 전환 애니메이션의 활성화 상태 제어
+  /** 전환 애니메이션의 활성화 상태를 제어합니다 */
   isExiting?: boolean;
-  // 전환 시 콘텐츠가 이동할 방향 지정
+  /** 전환 시 콘텐츠가 이동할 방향을 지정합니다 */
   exitDirection?: VariantProps<typeof contentVariants>['exitDirection'];
+  /** 컴포넌트의 색상 테마를 지정합니다 */
+  colorTheme?: VariantProps<typeof containerVariants>['colorTheme'];
 }
 
 /**
@@ -39,11 +68,12 @@ interface PixelTransitionProps extends PropsWithChildren<HTMLAttributes<HTMLDivE
  *     <PixelTransitionContainer
  *       isExiting={isExiting}
  *       exitDirection="left"
+ *       colorTheme="eastbay"
  *       className="min-h-screen"
  *     >
  *       <main className={cn(
  *         'min-h-screen',
- *         isExiting ? 'bg-transparent' : 'bg-violet-600'
+ *         isExiting ? 'bg-transparent' : 'bg-eastbay-600'
  *       )}>
  *         페이지 콘텐츠
  *       </main>
@@ -55,17 +85,15 @@ interface PixelTransitionProps extends PropsWithChildren<HTMLAttributes<HTMLDivE
 const PixelTransitionContainer = ({
   isExiting = false,
   exitDirection = 'left',
+  colorTheme = 'violet',
   children,
   className,
   ...props
 }: PixelTransitionProps) => {
   return (
     <div
-      className={cn(
-        'relative overflow-hidden transition-colors duration-700',
-        isExiting ? 'bg-violet-950' : 'bg-transparent',
-        className,
-      )}
+      className={cn(containerVariants({ colorTheme }), className)}
+      data-exiting={isExiting}
       aria-busy={isExiting}
       aria-live="polite"
       {...props}
@@ -82,11 +110,8 @@ const PixelTransitionContainer = ({
         {[...Array(100)].map((_, i) => (
           <div
             key={i}
-            className={cn(
-              'aspect-square border bg-transparent transition-[transform,border-color,background-color]',
-              'duration-600 border-transparent',
-              isExiting ? 'border-violet-800 bg-violet-500' : 'border-transparent bg-transparent',
-            )}
+            data-exiting={isExiting}
+            className={pixelVariants({ colorTheme })}
             style={{
               transitionDelay: `${((i % 7) + Math.floor(i / 7)) * 50}ms`,
               transform: isExiting ? 'scale(0.9) rotate(10deg)' : 'scale(1) rotate(0deg)',

--- a/client/src/components/ui/PixelTransitionContainer.tsx
+++ b/client/src/components/ui/PixelTransitionContainer.tsx
@@ -24,34 +24,28 @@ interface PixelTransitionProps extends PropsWithChildren<HTMLAttributes<HTMLDivE
 }
 
 /**
- * 페이지 페이드 아웃 시 전환 효과를 위한 컨테이너입니다.
+ * 페이지 전환 시 픽셀화 애니메이션 효과를 제공하는 컨테이너 컴포넌트입니다.
+ *
+ * @description
+ * 페이지 전환 시 콘텐츠를 부드럽게 전환하며, 픽셀화되는 효과를 보여줍니다.
+ * `usePageTransition` 훅과 함께 사용해야합니다.
  *
  * @example
  * ```tsx
  * const MyPage = () => {
- *   const [isExiting, setIsExiting] = useState(false);
- *
- *   const handleExit = () => {
- *     setIsExiting(true);
- *     // 애니메이션이 끝난 후 페이지 전환
- *     setTimeout(() => {
- *       // 페이지 전환 로직
- *     }, 1000);
- *   };
+ *   const { isExiting, transitionTo } = usePageTransition();
  *
  *   return (
  *     <PixelTransitionContainer
  *       isExiting={isExiting}
  *       exitDirection="left"
- *       className="h-screen w-screen"
+ *       className="min-h-screen"
  *     >
- *       <main
- *        className={cn(
- *          'h-screen w-screen',
- *          isExiting ? 'bg-transparent' : 'bg-violet-600',
- *        )}
- *       >
- *         내부 페이지 콘텐츠
+ *       <main className={cn(
+ *         'min-h-screen',
+ *         isExiting ? 'bg-transparent' : 'bg-violet-600'
+ *       )}>
+ *         페이지 콘텐츠
  *       </main>
  *     </PixelTransitionContainer>
  *   );

--- a/client/src/components/ui/PixelTransitionContainer.tsx
+++ b/client/src/components/ui/PixelTransitionContainer.tsx
@@ -1,0 +1,110 @@
+import { HTMLAttributes, PropsWithChildren } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/utils/cn';
+
+const contentVariants = cva('transition-transform duration-1000', {
+  variants: {
+    exitDirection: {
+      left: '-translate-x-full',
+      right: 'translate-x-full',
+      up: '-translate-y-full',
+      down: 'translate-y-full',
+    },
+  },
+  defaultVariants: {
+    exitDirection: 'left',
+  },
+});
+
+interface PixelTransitionProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
+  // 전환 애니메이션의 활성화 상태 제어
+  isExiting?: boolean;
+  // 전환 시 콘텐츠가 이동할 방향 지정
+  exitDirection?: VariantProps<typeof contentVariants>['exitDirection'];
+}
+
+/**
+ * 페이지 페이드 아웃 시 전환 효과를 위한 컨테이너입니다.
+ *
+ * @example
+ * ```tsx
+ * const MyPage = () => {
+ *   const [isExiting, setIsExiting] = useState(false);
+ *
+ *   const handleExit = () => {
+ *     setIsExiting(true);
+ *     // 애니메이션이 끝난 후 페이지 전환
+ *     setTimeout(() => {
+ *       // 페이지 전환 로직
+ *     }, 1000);
+ *   };
+ *
+ *   return (
+ *     <PixelTransitionContainer
+ *       isExiting={isExiting}
+ *       exitDirection="left"
+ *       className="h-screen w-screen"
+ *     >
+ *       <main
+ *        className={cn(
+ *          'h-screen w-screen',
+ *          isExiting ? 'bg-transparent' : 'bg-violet-600',
+ *        )}
+ *       >
+ *         내부 페이지 콘텐츠
+ *       </main>
+ *     </PixelTransitionContainer>
+ *   );
+ * };
+ * ```
+ */
+const PixelTransitionContainer = ({
+  isExiting = false,
+  exitDirection = 'left',
+  children,
+  className,
+  ...props
+}: PixelTransitionProps) => {
+  return (
+    <div
+      className={cn(
+        'relative overflow-hidden transition-colors duration-700',
+        isExiting ? 'bg-transparent' : 'bg-violet-950',
+        className,
+      )}
+      aria-busy={isExiting}
+      aria-live="polite"
+      {...props}
+    >
+      {/* 픽셀 그리드 오버레이 */}
+      <div
+        className={cn(
+          'absolute inset-0 transition-all duration-700',
+          'grid aspect-square grid-cols-5 xs:grid-cols-6 sm:grid-cols-7 md:grid-cols-8 lg:grid-cols-9 xl:grid-cols-10',
+          isExiting ? 'z-50 opacity-100' : 'z-0 opacity-0',
+        )}
+        aria-hidden="true"
+      >
+        {[...Array(100)].map((_, i) => (
+          <div
+            key={i}
+            className={cn(
+              'aspect-square border bg-transparent transition-[transform,border-color,background-color]',
+              'duration-600 border-transparent',
+              isExiting ? 'border-violet-800 bg-violet-500' : 'border-transparent bg-transparent',
+            )}
+            style={{
+              transitionDelay: `${((i % 7) + Math.floor(i / 7)) * 50}ms`,
+              transform: isExiting ? 'scale(0.9) rotate(10deg)' : 'scale(1) rotate(0deg)',
+            }}
+          />
+        ))}
+      </div>
+
+      {/* 콘텐츠 */}
+      <div className={cn('relative', isExiting && contentVariants({ exitDirection }))}>{children}</div>
+    </div>
+  );
+};
+
+export { PixelTransitionContainer };

--- a/client/src/hooks/usePageTransition.ts
+++ b/client/src/hooks/usePageTransition.ts
@@ -1,0 +1,63 @@
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface UsePageTransitionOptions {
+  /**
+   * 트랜지션 애니메이션의 지속 시간 (밀리초)
+   * 지속 시간이 끝나면 navigate 됨
+   * @default 1000
+   */
+  duration?: number;
+}
+
+/**
+ * 페이지 전환 애니메이션을 관리하는 커스텀 훅입니다.
+ *
+ * @description
+ * 페이지 전환 시 애니메이션을 자연스럽게 처리하며, 라우팅과 상태 관리를 캡슐화합니다.
+ * 필수로 `PixelTransitionContainer` 컴포넌트와 함께 사용해야 합니다.
+ *
+ * @param options - 페이지 전환 옵션
+ * @returns 전환 상태와 페이지 전환 함수를 포함하는 객체
+ *
+ * @example
+ * ```tsx
+ * const MyPage = () => {
+ *   const { isExiting, transitionTo } = usePageTransition();
+ *
+ *   const handleNavigate = () => {
+ *     transitionTo('/next-page');
+ *   };
+ *
+ *   return (
+ *     <PixelTransitionContainer isExiting={isExiting}>
+ *       <button onClick={handleNavigate}>다음 페이지로</button>
+ *     </PixelTransitionContainer>
+ *   );
+ * };
+ * ```
+ */
+export const usePageTransition = ({ duration = 1000 }: UsePageTransitionOptions = {}) => {
+  const navigate = useNavigate();
+  const [isExiting, setIsExiting] = useState(false);
+
+  const transitionTo = useCallback(
+    (path: string) => {
+      setIsExiting(true);
+      setTimeout(() => {
+        navigate(path);
+      }, duration);
+    },
+    [navigate, duration],
+  );
+
+  return {
+    /** 현재 페이지가 전환 중인지 여부 */
+    isExiting,
+    /**
+     * 지정된 경로로 애니메이션과 함께 페이지를 전환합니다
+     * @param path - 이동할 페이지의 경로
+     */
+    transitionTo,
+  };
+};

--- a/client/src/layouts/RootLayout.tsx
+++ b/client/src/layouts/RootLayout.tsx
@@ -6,7 +6,7 @@ const RootLayout = () => {
   return (
     <div className="relative min-h-screen bg-violet-950 bg-fixed antialiased">
       {/* 상단 네비게이션 영역: Help 아이콘 컴포넌트 */}
-      <nav className="fixed right-4 top-4 z-50 animate-bounce xs:right-8 xs:top-8">
+      <nav className="fixed right-4 top-4 z-30 animate-bounce xs:right-8 xs:top-8">
         <Button variant="transperent" size="icon">
           <img src={helpIcon} alt="도움말 보기 버튼" />
         </Button>

--- a/client/src/pages/ExamplePage.tsx
+++ b/client/src/pages/ExamplePage.tsx
@@ -38,7 +38,7 @@ const ExamplePage = () => {
             <UserInfoCard username="미라" status={isReady ? 'ready' : 'notReady'} />
             <UserInfoCard username="친구" status={'notReady'} />
           </div>
-          <Button onClick={() => setIsReady(!isReady)} variant={isReady ? 'secondary' : 'proimary'} className="w-full">
+          <Button onClick={() => setIsReady(!isReady)} variant={isReady ? 'secondary' : 'primary'} className="w-full">
             {isReady ? '해제' : '준비'}
           </Button>
         </div>

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,30 +1,25 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/Button';
 import { Logo } from '@/components/ui/Logo';
 import { PixelTransitionContainer } from '@/components/ui/PixelTransitionContainer';
+import { usePageTransition } from '@/hooks/usePageTransition';
 import { cn } from '@/utils/cn';
 
 const MainPage = () => {
-  const navigate = useNavigate();
-  const [isExiting, setIsExiting] = useState(false);
+  const { isExiting, transitionTo } = usePageTransition();
 
   const handleCreateRoom = () => {
     // 서버 통신 로직이 들어갈 자리
     // const response = await createRoom();
     // const { roomId } = response.data;
 
-    setIsExiting(true);
-    setTimeout(() => {
-      navigate('/waiting-room/123');
-    }, 1000);
+    transitionTo('/waiting-room/123');
   };
 
   return (
     <PixelTransitionContainer isExiting={isExiting}>
       <main
         className={cn(
-          'flex h-screen w-screen flex-col items-center justify-center gap-8 px-4 sm:gap-16',
+          'flex min-h-screen flex-col items-center justify-center gap-8 px-4 sm:gap-16',
           isExiting ? 'bg-transparent' : 'bg-gradient-to-b from-violet-950 via-violet-800 to-fuchsia-700',
         )}
       >
@@ -32,7 +27,7 @@ const MainPage = () => {
           <Logo variant="main" className="w-full transition duration-300 hover:scale-110 hover:brightness-[1.12]" />
         </div>
 
-        <Button onClick={handleCreateRoom} className="h-12 max-w-[280px] animate-pulse">
+        <Button onClick={handleCreateRoom} className="h-12 max-w-72 animate-pulse">
           방 만들기
         </Button>
       </main>

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,14 +1,42 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/Button';
 import { Logo } from '@/components/ui/Logo';
+import { PixelTransitionContainer } from '@/components/ui/PixelTransitionContainer';
+import { cn } from '@/utils/cn';
 
 const MainPage = () => {
+  const navigate = useNavigate();
+  const [isExiting, setIsExiting] = useState(false);
+
+  const handleCreateRoom = () => {
+    // 서버 통신 로직이 들어갈 자리
+    // const response = await createRoom();
+    // const { roomId } = response.data;
+
+    setIsExiting(true);
+    setTimeout(() => {
+      navigate('/waiting-room/123');
+    }, 1000);
+  };
+
   return (
-    <main className="flex h-screen items-center justify-center bg-gradient-to-b from-violet-950 via-violet-800 to-fuchsia-700">
-      <div className="flex h-full flex-col items-center justify-center gap-16">
-        <Logo variant="main" />
-        <Button className="h-16 max-w-96">방 만들기</Button>
-      </div>
-    </main>
+    <PixelTransitionContainer isExiting={isExiting}>
+      <main
+        className={cn(
+          'flex h-screen w-screen flex-col items-center justify-center gap-8 px-4 sm:gap-16',
+          isExiting ? 'bg-transparent' : 'bg-gradient-to-b from-violet-950 via-violet-800 to-fuchsia-700',
+        )}
+      >
+        <div className="duration-1000 animate-in fade-in slide-in-from-top-8">
+          <Logo variant="main" className="w-full transition duration-300 hover:scale-110 hover:brightness-[1.12]" />
+        </div>
+
+        <Button onClick={handleCreateRoom} className="h-12 max-w-[280px] animate-pulse">
+          방 만들기
+        </Button>
+      </main>
+    </PixelTransitionContainer>
   );
 };
 

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -23,7 +23,7 @@ export const router = createBrowserRouter([
             element: <ExamplePage />,
           },
           // {
-          //   path: '/room/:roomId',
+          //   path: '/waiting-room/:roomId',
           //   element: <WaitingRoomPage />,
           // },
           // {

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,3 +1,5 @@
+import tailwindcssAnimate from 'tailwindcss-animate';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
@@ -76,6 +78,9 @@ export default {
     },
   },
   plugins: [
+    // tailwindcss-animate import
+    tailwindcssAnimate,
+    // text-stroke
     function ({ addUtilities }) {
       addUtilities({
         '.text-stroke-sm': {


### PR DESCRIPTION
## 📂 작업 내용

closes #15

- [x] 페이지 전환 애니메이션 및 로고 호버 효과 추가
- [x] `PixelTransitionContainer` 컴포넌트를 이용한 커스터마이징 가능한 페이드 아웃 전환 효과 구현
- [x] 메인 페이지 전환, 네비게이션 및 레이아웃 조정 작업 완료

## 💡 자세한 설명

- **PixelTransitionContainer 컴포넌트 추가**
  - 페이지 전환 시 픽셀 그리드 기반 슬라이드 아웃 애니메이션 적용, 애니메이션 방향(좌/우/상/하) 설정 가능. 
  - 스크린 리더를 위한 접근성 속성(ARIA)도 포함.
- **버튼 및 스타일 최적화**
  - 버튼의 변형명 오타를 수정(‘proimary’에서 ‘primary’로).
  - Button 컴포넌트의 기본 스타일을 단순화하고, 반응형 스타일링은 구현 레벨로 이동하여 일관성 유지.
- **TailwindCSS 플러그인 추가**
  - `tailwindcss-animate` 플러그인 사용해 애니메이션 효과 적용.
- **메인 페이지의 디자인 개선**
  - `setTimeout` + 임시 라우팅 로직을 구현하고, 페이지 전환에 픽셀 그리드 효과를 적용해 부드러운 전환을 제공.
  - 로고에 호버 애니메이션 추가.

## 📗 참고 자료 & 구현 결과 

https://github.com/user-attachments/assets/103eeb70-8cf1-4b38-bb4e-594ba7d8b0b6

나중에 사각형 안에 이미지 같은 걸 넣어도 될 듯?

## 📢 리뷰 요구 사항

- PixelTransitionContainer의 접근성 속성 검토 필요
- 페이지 전환 애니메이션의 방향 설정이 UX에 적합한지 확인

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?