### PR TITLE
feat: Implement round end result modal 

### DIFF
--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -38,8 +38,8 @@ const Modal = ({ className, handleKeyDown, closeModal, isModalOpened, title, chi
         tabIndex={0}
         {...props}
       >
-        <div className="flex min-h-16 items-center justify-center border-b-2 border-violet-950 bg-violet-500 px-3 py-3">
-          <h2 className="translate-y-1 text-4xl text-stroke-md">{title}</h2>
+        <div className="flex min-h-16 items-center justify-center border-b-2 border-violet-950 bg-violet-500 px-3 py-3 text-center">
+          <h2 className="translate-y-1 text-3xl text-stroke-md sm:text-4xl">{title}</h2>
         </div>
         <div className="p-5">{children}</div>
       </div>

--- a/client/src/hooks/useModal.ts
+++ b/client/src/hooks/useModal.ts
@@ -25,7 +25,7 @@ import { timer } from '@/utils/timer';
  * @category Hooks
  */
 
-export const useModal = (autoCloseDelay: number) => {
+export const useModal = (autoCloseDelay?: number) => {
   const [isModalOpened, setModalOpened] = useState<boolean>(false);
 
   const closeModal = () => {

--- a/client/src/pages/ExamplePage.tsx
+++ b/client/src/pages/ExamplePage.tsx
@@ -14,12 +14,12 @@ import { useModal } from '@/hooks/useModal';
 const ExamplePage = () => {
   const [isReady, setIsReady] = useState(false);
   const { isModalOpened, openModal } = useModal(3000);
+  const { isModalOpened: isModalOpened2, openModal: openModal2, closeModal } = useModal();
 
   return (
     <main className="bg-eastbay-600">
       <Logo />
       <Logo variant="side" />
-
       <div className="flex items-center justify-center">
         <GameCanvas role="방해꾼" />
       </div>
@@ -62,6 +62,26 @@ const ExamplePage = () => {
       <button onClick={openModal}>3초 후 사라지는 Role 모달 오픈</button>
       <Modal title="역할 배정" isModalOpened={isModalOpened} className="w-80">
         <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">그림꾼</span>
+      </Modal>
+
+      {/* 라운드 종료 모달 */}
+      <button onClick={openModal2}>라운드 종료 모달 오픈</button>
+      <Modal
+        title="제시어 : 티라노사우르스"
+        isModalOpened={isModalOpened2}
+        closeModal={closeModal}
+        className="max-w-[26.875rem] sm:max-w-[61.75rem]"
+      >
+        <div className="flex min-h-[12rem] items-center justify-center sm:min-h-[15.75rem]">
+          <p className="text-center text-2xl sm:m-2 sm:text-3xl">
+            구경꾼 <span className="text-violet-600">태연태연</span>이 정답을 맞혔습니다
+          </p>
+        </div>
+        <div className="min-h-[4rem] rounded-md bg-violet-50 p-4 sm:m-2">
+          <p className="text-center text-xl text-violet-950 sm:text-2xl">
+            방해꾼은 <span className="text-violet-600">미라미라</span>였습니다.
+          </p>
+        </div>
       </Modal>
     </main>
   );


### PR DESCRIPTION
## 📂 작업 내용

closes #52 

- [x] Modal 공통 컴포넌트를 사용해 구현한다
- [x] 반응형을 고려해야한다.

## 💡 자세한 설명

- 라운드 결과 모달을 구현하였습니다.
- 제시어, 방해군, 맞춘 구경꾼이 화면에 나타납니다.
- 화면이 640px보다 작아지면 모달과 폰트 크기도 작아지도록 구현하였습니다. 

## 📗 참고 자료 & 구현 결과 (선택)

![modal](https://github.com/user-attachments/assets/8cb30982-100c-42d1-a069-c8c5c5f89f69)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
