### PR TITLE
feat: Implement room settings update

### DIFF
--- a/server/src/game/game.repository.ts
+++ b/server/src/game/game.repository.ts
@@ -41,6 +41,7 @@ export class GameRepository {
 
   async getRoomSettings(roomId: string) {
     const settings = await this.redisService.hgetall(`room:${roomId}:settings`);
+
     return {
       maxPlayers: parseInt(settings.maxPlayers, 10),
       totalRounds: parseInt(settings.totalRounds, 10),
@@ -79,5 +80,9 @@ export class GameRepository {
     multi.lrem(`room:${roomId}:players`, 0, playerId);
     multi.del(`room:${roomId}:players:${playerId}`);
     await multi.exec();
+  }
+
+  async updateRoomSettings(roomId: string, settings: RoomSettings) {
+    await this.redisService.hset(`room:${roomId}:settings`, settings);
   }
 }


### PR DESCRIPTION
## 📂 작업 내용

closes #94 

- [x] 방장은 방의 설정을 변경할 수 있다.
- [x] 방장을 제외한 플레이어는 변경사항을 전달받는다. 

## 💡 자세한 설명

- 웹소켓을 통한 방 설정 수정 엔드포인트 추가
- 방장 전용 설정 수정 권한 구현
- Redis를 활용한 설정 데이터 저장 로직 추가
- 예외 처리 및 유효성 검사 추가

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
