### PR TITLE
fix: Resolve duplicate timers and reconnection timing issues in handleDisconnect

### DIFF
--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -20,6 +20,9 @@ export class GameGateway implements OnGatewayDisconnect {
   @WebSocketServer()
   server: Server;
 
+  private disconnectTimeouts: Map<string, NodeJS.Timeout> = new Map();
+  private readonly DISCONNECT_TIMEOUT = 10000;
+
   constructor(private readonly gameService: GameService) {}
 
   @SubscribeMessage('joinRoom')
@@ -65,18 +68,29 @@ export class GameGateway implements OnGatewayDisconnect {
     const { playerId, roomId } = client.data;
     if (!playerId || !roomId) return;
 
-    setTimeout(async () => {
-      const sockets = await this.server.fetchSockets();
-      const isReconnected = sockets.some((socket) => socket.data.playerId === playerId);
+    const existingTimeout = this.disconnectTimeouts.get(playerId);
+    if (existingTimeout) {
+      clearTimeout(existingTimeout);
+      this.disconnectTimeouts.delete(playerId);
+    }
 
-      if (!isReconnected) {
-        const players = await this.gameService.leaveRoom(roomId, playerId);
-        if (!players) return;
-        this.server.to(roomId).emit('playerLeft', {
-          leftPlayerId: playerId,
-          players,
-        });
+    const timeout = setTimeout(async () => {
+      try {
+        const sockets = await this.server.fetchSockets();
+        const isReconnected = sockets.some((socket) => socket.data.playerId === playerId);
+
+        if (!isReconnected) {
+          const players = await this.gameService.leaveRoom(roomId, playerId);
+          if (!players) return;
+          this.server.to(roomId).emit('playerLeft', {
+            leftPlayerId: playerId,
+            players,
+          });
+        }
+      } finally {
+        this.disconnectTimeouts.delete(playerId);
       }
-    }, 10000);
+    }, this.DISCONNECT_TIMEOUT);
+    this.disconnectTimeouts.set(playerId, timeout);
   }
 }


### PR DESCRIPTION
## 📂 작업 내용

closes #93 

- [x] handleDisconnect 중복 타이머 및 재연결 타이밍 문제 해결

## 💡 자세한 설명

- Map을 사용하여 플레이어별 연결 해제 타임아웃 관리 구현
- 연속된 새로고침 시 이전 타임아웃 취소 처리 추가
- 재접속 없을 경우에만 플레이어 데이터 삭제하도록 개선
- 타임아웃 완료 후 메모리 정리 로직 추가

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
