### PR TITLE
feat: Implement player role distribution on game start

### DIFF
--- a/server/src/common/enums/game.status.enum.ts
+++ b/server/src/common/enums/game.status.enum.ts
@@ -1,6 +1,5 @@
 export enum PlayerStatus {
-  NOT_READY = 'NOT_READY',
-  READY = 'READY',
+  NOT_PLAYING = 'NOT_PLAYING',
   PLAYING = 'PLAYING',
 }
 

--- a/server/src/exceptions/game.exception.ts
+++ b/server/src/exceptions/game.exception.ts
@@ -32,3 +32,9 @@ export class BadRequestException extends GameException {
     super(SocketErrorCode.BAD_REQUEST, message);
   }
 }
+
+export class InsufficientPlayersException extends GameException {
+  constructor(message: string = 'Insufficient players') {
+    super(SocketErrorCode.INSUFFICIENT_PLAYERS, message);
+  }
+}

--- a/server/src/game/game.repository.ts
+++ b/server/src/game/game.repository.ts
@@ -36,6 +36,7 @@ export class GameRepository {
     const multi = this.redisService.multi();
     multi.del(`room:${roomId}`);
     multi.del(`room:${roomId}:settings`);
+    multi.del(`room:${roomId}:players`);
     await multi.exec();
   }
 
@@ -84,5 +85,9 @@ export class GameRepository {
 
   async updateRoomSettings(roomId: string, settings: RoomSettings) {
     await this.redisService.hset(`room:${roomId}:settings`, settings);
+  }
+
+  async updatePlayer(roomId: string, playerId: string, player: Player) {
+    await this.redisService.hset(`room:${roomId}:players:${playerId}`, player);
   }
 }


### PR DESCRIPTION
## 📂 작업 내용

closes #93 

- [x] 라운드 시작 구현

## 💡 자세한 설명

- 방 활성화
- 플레이어 활성화
- 게임 시작 시 플레이어들을 무작위로 섞어 역할 할당
- 첫 2명은 그림꾼, 3번째는 방해꾼, 나머지는 구경꾼로 지정
- 역할별로 다른 이벤트 및 데이터 전송

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
