### PR TITLE
feat: Implement socket connection in Setting component for real-time updates

### DIFF
--- a/client/src/components/setting/Setting.tsx
+++ b/client/src/components/setting/Setting.tsx
@@ -19,7 +19,7 @@ interface SettingProps extends HTMLAttributes<HTMLDivElement> {
 export const ROOM_SETTINGS: RoomSettingItem[] = [
   { label: '라운드 수', key: 'totalRounds', options: [3, 5] },
   { label: '플레이어 수', key: 'maxPlayers', options: [4, 5] },
-  { label: '제한 시간', key: 'drawTime', options: [15, 30] },
+  { label: '제한 시간', key: 'drawTime', options: [15, 20, 25, 30] },
   //{ label: '픽셀 수', key: 'maxPixels', options: [300, 500] },
 ];
 

--- a/client/src/components/setting/Setting.tsx
+++ b/client/src/components/setting/Setting.tsx
@@ -1,6 +1,7 @@
-import { HTMLAttributes, useState } from 'react';
+import { HTMLAttributes, useEffect, useState } from 'react';
 import { RoomSettings } from '@troublepainter/core';
 import Dropdown from '@/components/ui/Dropdown';
+import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 import { cn } from '@/utils/cn';
 
 type SettingKey = keyof RoomSettings;
@@ -12,24 +13,31 @@ interface RoomSettingItem {
 }
 
 interface SettingProps extends HTMLAttributes<HTMLDivElement> {
-  roomSettings?: RoomSettings;
   type: 'host' | 'participant';
 }
 
 export const ROOM_SETTINGS: RoomSettingItem[] = [
-  { label: '라운드 수', key: 'totalRounds', options: [4, 6, 8] },
-  { label: '플레이어 수', key: 'maxPlayers', options: [4, 5, 6] },
+  { label: '라운드 수', key: 'totalRounds', options: [3, 5] },
+  { label: '플레이어 수', key: 'maxPlayers', options: [4, 5] },
   { label: '제한 시간', key: 'drawTime', options: [15, 30] },
-  { label: '픽셀 수', key: 'maxPixels', options: [300, 500] },
+  //{ label: '픽셀 수', key: 'maxPixels', options: [300, 500] },
 ];
 
-const Setting = ({ className, roomSettings, type, ...props }: SettingProps) => {
+const Setting = ({ className, type, ...props }: SettingProps) => {
+  const { roomSettings, actions } = useGameSocketStore();
+
   const [selectedValues, setSelectedValues] = useState<RoomSettings>({
-    totalRounds: roomSettings?.totalRounds || 4,
-    maxPlayers: roomSettings?.maxPlayers || 4,
+    totalRounds: roomSettings?.totalRounds || 5,
+    maxPlayers: roomSettings?.maxPlayers || 5,
     drawTime: roomSettings?.drawTime || 30,
-    maxPixels: roomSettings?.drawTime || 300,
+    maxPixels: roomSettings?.maxPixels || 300,
   });
+
+  useEffect(() => {
+    if (type === 'participant') return;
+    //console.log(selectedValues);
+    actions.updateRoomSettings(selectedValues);
+  }, [selectedValues]);
 
   const handleChange = (key: SettingKey) => (value: string) => {
     setSelectedValues((prev) => ({
@@ -56,7 +64,7 @@ const Setting = ({ className, roomSettings, type, ...props }: SettingProps) => {
           {ROOM_SETTINGS.map(({ label, key, options }) => (
             <div key={label} className="flex w-full max-w-80 items-center justify-between sm:max-w-[70%]">
               <span>{label}</span>
-              {type === 'participant' ? (
+              {type === 'host' ? (
                 <span>{selectedValues[key]}</span>
               ) : (
                 <Dropdown

--- a/client/src/components/setting/Setting.tsx
+++ b/client/src/components/setting/Setting.tsx
@@ -64,7 +64,7 @@ const Setting = ({ className, type, ...props }: SettingProps) => {
       <div className="flex min-h-[16.125rem] items-center justify-center bg-violet-200 sm:min-h-[18.56rem] sm:rounded-b-xl sm:px-6">
         <div className="flex min-h-[13.8rem] w-full flex-col items-center justify-center gap-4 border-0 border-violet-950 bg-violet-50 p-4 text-xl sm:h-auto sm:rounded-[0.625rem] sm:border-2 lg:gap-6 lg:text-2xl">
           {ROOM_SETTINGS.map(({ label, key, options }) => (
-            <div key={label} className="flex w-full max-w-80 items-center justify-between sm:max-w-[70%]">
+            <div key={label} className="flex w-full max-w-80 items-center justify-between lg:max-w-[80%]">
               <span>{label}</span>
               {type === 'participant' ? (
                 <span>{roomSettings?.[key] || ''}</span>

--- a/client/src/components/setting/Setting.tsx
+++ b/client/src/components/setting/Setting.tsx
@@ -64,7 +64,7 @@ const Setting = ({ className, type, ...props }: SettingProps) => {
           {ROOM_SETTINGS.map(({ label, key, options }) => (
             <div key={label} className="flex w-full max-w-80 items-center justify-between sm:max-w-[70%]">
               <span>{label}</span>
-              {type === 'host' ? (
+              {type === 'participant' ? (
                 <span>{selectedValues[key]}</span>
               ) : (
                 <Dropdown

--- a/client/src/hooks/socket/useGameSocket.ts
+++ b/client/src/hooks/socket/useGameSocket.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import type { JoinRoomResponse, PlayerLeftResponse } from '@troublepainter/core';
+import type { JoinRoomResponse, PlayerLeftResponse, UpdateSettingsResponse } from '@troublepainter/core';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 import { SocketNamespace } from '@/stores/socket/socket.config';
 import { useSocketStore } from '@/stores/socket/socket.store';
@@ -121,6 +121,11 @@ export const useGameSocket = () => {
         const { leftPlayerId, players } = response;
         gameActions.removePlayer(leftPlayerId);
         gameActions.updatePlayers(players);
+      },
+
+      settingsUpdated: (response: UpdateSettingsResponse) => {
+        const { settings } = response;
+        gameActions.updateRoomSettings(settings);
       },
     };
 

--- a/client/src/stores/socket/gameSocket.store.ts
+++ b/client/src/stores/socket/gameSocket.store.ts
@@ -1,4 +1,4 @@
-import { Player, Room, RoomSettings } from '@troublepainter/core';
+import { Player, Room, RoomSettings, UpdateSettingsRequest } from '@troublepainter/core';
 import { JoinRoomRequest, JoinRoomResponse, ReconnectRequest } from '@troublepainter/core';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
@@ -23,7 +23,7 @@ interface GameActions {
   joinRoom: (request: JoinRoomRequest) => Promise<JoinRoomResponse>;
   reconnect: (request: ReconnectRequest) => Promise<void>;
   // updatePlayerStatus: (request: ReadyRequest) => Promise<void>;
-  // updateSettings: (request: UpdateSettingsRequest) => Promise<void>;
+  updateSettings: (request: UpdateSettingsRequest) => Promise<void>;
   // leaveRoom: () => Promise<void>;
 
   // 상태 초기화
@@ -148,21 +148,14 @@ export const useGameSocketStore = create<GameState & { actions: GameActions }>()
         //   });
         // },
 
-        // updateSettings: async (request) => {
-        //   const socket = useSocketStore.getState().sockets.game;
-        //   if (!socket) throw new Error('Socket not connected');
+        updateSettings: async (request) => {
+          const socket = useSocketStore.getState().sockets.game;
+          if (!socket) throw new Error('Socket not connected');
 
-        //   return new Promise((resolve, reject) => {
-        //     socket.emit('updateSettings', request, (error?: SocketError) => {
-        //       if (error) {
-        //         set({ error });
-        //         reject(error);
-        //       } else {
-        //         resolve();
-        //       }
-        //     });
-        //   });
-        // },
+          return new Promise(() => {
+            socket.emit('updateSettings', request);
+          });
+        },
 
         // leaveRoom: async () => {
         //   const socket = useSocketStore.getState().sockets.game;


### PR DESCRIPTION
## 📂 작업 내용

closes #100 

- [x] 방 생성시 기본 설정 maxPlayers:5, totalRounds:5, drawTime:30
- [x] 설정 maxPlayers:(4,5), totalRound:(3,5), drawTime:(15, 20, 25, 30)
- [x] 방장은 설정을 변경할 수 있음
- [x] 방장이 아닌 참가자는 설정을 확인할 수 있음

## 💡 자세한 설명

- updateSetting 요청은 gameSocketStore에 구현하였습니다.
- settingsUpdated 응답은 useGameSocket에 구현하였습니다.
- 방 생성시 기본적으로 maxPlayers:5, totalRounds:5, drawTime:30로 설정됩니다.
- 설정은 maxPlayers:(4,5), totalRound:(3,5), drawTime:(15, 20, 25, 30) 가능합니다. 
- type이 participant면(방장x) 설정을 변경할 수 없도록 하였습니다.
- type이 host이면(방장o) 설정을 변경할 수 있도록 하였습니다. 


## 📗 참고 자료 & 구현 결과 (선택)

- 실시간 반영 
![socket1](https://github.com/user-attachments/assets/06336fd6-e614-4e69-bbca-03140c769fba)

- 플레이어수 -> 최대 플레이어 수 레이아웃 
![layout](https://github.com/user-attachments/assets/8d7311df-9da4-459f-ade2-36635d47e0f1)


## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
