### PR TITLE
refactor: Separate socket handlers and organize socket-related code structure

### DIFF
--- a/client/src/components/canvas/GameCanvas.tsx
+++ b/client/src/components/canvas/GameCanvas.tsx
@@ -2,6 +2,7 @@ import { MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent, useCallba
 import { PlayerRole } from '@troublepainter/core';
 import { Canvas } from '@/components/canvas/CanvasUI';
 import { COLORS_INFO, MAINCANVAS_RESOLUTION_WIDTH } from '@/constants/canvasConstants';
+import { drawingSocketHandlers } from '@/handlers/socket/drawingSocket.handler';
 import { useDrawingSocket } from '@/hooks/socket/useDrawingSocket';
 import { useCoordinateScale } from '@/hooks/useCoordinateScale';
 import { useDrawing } from '@/hooks/useDrawing';
@@ -68,7 +69,7 @@ const GameCanvas = ({ role, maxPixels = 100000 }: GameCanvasProps) => {
     maxPixels,
   });
 
-  const { isConnected, sendDrawing } = useDrawingSocket({
+  const { isConnected } = useDrawingSocket({
     onDrawUpdate: (response) => {
       if (response.drawingData) {
         applyDrawing(response.drawingData);
@@ -101,10 +102,10 @@ const GameCanvas = ({ role, maxPixels = 100000 }: GameCanvasProps) => {
     // console.log(currentDrawing, isConnected);
     if (currentDrawing && isConnected) {
       // console.log(currentDrawing);
-      sendDrawing(currentDrawing);
+      void drawingSocketHandlers.sendDrawing(currentDrawing);
     }
     stopDrawing();
-  }, [stopDrawing, sendDrawing, getCurrentDrawing, isConnected]);
+  }, [stopDrawing, getCurrentDrawing, isConnected]);
 
   const isDrawableRole = (role: PlayerRole): role is PlayerRole.PAINTER | PlayerRole.DEVIL => {
     return role === 'PAINTER' || role === 'DEVIL';

--- a/client/src/components/ui/PlayerCard.stories.tsx
+++ b/client/src/components/ui/PlayerCard.stories.tsx
@@ -1,4 +1,4 @@
-import { PlayerRole, PlayerStatus } from '@troublepainter/core';
+import { PlayerRole } from '@troublepainter/core';
 import { PlayerCard } from './PlayerCard';
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -10,7 +10,7 @@ export default {
   argTypes: {
     status: {
       control: 'select',
-      options: ['notReady', 'ready', 'gaming'],
+      options: ['NOT_PLAYING', 'PLAYING'],
       description: '사용자의 현재 상태',
     },
     nickname: {
@@ -27,8 +27,12 @@ export default {
     },
     role: {
       control: 'select',
-      options: ['그림꾼', '방해꾼', '구경꾼'],
+      options: [PlayerRole.PAINTER, PlayerRole.DEVIL, PlayerRole.GUESSER],
       description: '게임에서의 역할',
+    },
+    isHost: {
+      control: 'boolean',
+      description: '방장 여부',
     },
     className: {
       control: 'text',
@@ -41,6 +45,12 @@ export default {
   },
   parameters: {
     layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '게임 참여자의 정보를 표시하는 카드 컴포넌트입니다. 상태에 따라 게임 진행 중/대기 중 모드로 표시되며, 방장일 경우 별도의 스타일이 적용됩니다.',
+      },
+    },
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof PlayerCard>;
@@ -48,23 +58,61 @@ export default {
 export const Default: Story = {
   args: {
     nickname: 'Player1',
-    status: PlayerStatus.NOT_READY,
+    status: 'NOT_PLAYING',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '기본적인 플레이어 카드 상태입니다.',
+      },
+    },
   },
 };
 
-export const Ready: Story = {
+export const Host: Story = {
   args: {
     nickname: 'Player1',
-    status: PlayerStatus.READY,
+    status: 'NOT_PLAYING',
+    isHost: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '방장인 플레이어의 카드 상태입니다. 보라색 배경과 "방장" 태그가 표시됩니다.',
+      },
+    },
   },
 };
 
 export const Gaming: Story = {
   args: {
     nickname: 'Player1',
-    status: PlayerStatus.PLAYING,
+    status: 'PLAYING',
     role: PlayerRole.PAINTER,
     score: 100,
     rank: 1,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '게임 진행 중인 플레이어의 카드입니다. 역할과 점수가 표시되며, 상위 랭크의 경우 왕관이 표시됩니다.',
+      },
+    },
+  },
+};
+
+export const LongNickname: Story = {
+  args: {
+    nickname: 'VeryLongPlayerNameThatShouldBeTruncated',
+    status: 'PLAYING',
+    role: PlayerRole.DEVIL,
+    score: 75,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '긴 닉네임이 주어졌을 때의 처리를 보여줍니다. 닉네임이 길 경우 말줄임표로 표시됩니다.',
+      },
+    },
   },
 };

--- a/client/src/handlers/socket/chatSocket.handler.ts
+++ b/client/src/handlers/socket/chatSocket.handler.ts
@@ -1,0 +1,15 @@
+import { useSocketStore } from '@/stores/socket/socket.store';
+
+export const chatSocketHandlers = {
+  sendMessage: (message: string): Promise<void> => {
+    const socket = useSocketStore.getState().sockets.chat;
+    if (!socket) throw new Error('Chat Socket not connected');
+
+    return new Promise((resolve) => {
+      socket.emit('sendMessage', { message: message.trim() });
+      resolve();
+    });
+  },
+};
+
+export type ChatSocketHandlers = typeof chatSocketHandlers;

--- a/client/src/handlers/socket/drawingSocket.handler.ts
+++ b/client/src/handlers/socket/drawingSocket.handler.ts
@@ -1,0 +1,17 @@
+import type { DrawingData } from '@troublepainter/core';
+import { useSocketStore } from '@/stores/socket/socket.store';
+
+export const drawingSocketHandlers = {
+  // 드로잉 데이터 전송
+  sendDrawing: (drawingData: DrawingData): Promise<void> => {
+    const socket = useSocketStore.getState().sockets.drawing;
+    if (!socket) throw new Error('Socket not connected');
+
+    return new Promise((resolve) => {
+      socket.emit('draw', { drawingData });
+      resolve();
+    });
+  },
+};
+
+export type DrawSocketHandlers = typeof drawingSocketHandlers;

--- a/client/src/handlers/socket/gameSocket.handler.ts
+++ b/client/src/handlers/socket/gameSocket.handler.ts
@@ -1,0 +1,69 @@
+import type { JoinRoomRequest, JoinRoomResponse, ReconnectRequest } from '@troublepainter/core';
+import { useSocketStore } from '@/stores/socket/socket.store';
+
+// socket 요청만 처리하는 핸들러
+export const gameSocketHandlers = {
+  joinRoom: (request: JoinRoomRequest): Promise<JoinRoomResponse> => {
+    const socket = useSocketStore.getState().sockets.game;
+    if (!socket) throw new Error('Socket not connected');
+
+    return new Promise(() => {
+      socket.emit('joinRoom', request);
+    });
+  },
+
+  reconnect: (request: ReconnectRequest): Promise<void> => {
+    const socket = useSocketStore.getState().sockets.game;
+    if (!socket) throw new Error('Socket not connected');
+
+    return new Promise(() => {
+      socket.emit('reconnect', request);
+    });
+  },
+
+  // updatePlayerStatus: async (request) => {
+  //   const socket = useSocketStore.getState().sockets.game;
+  //   if (!socket) throw new Error('Socket not connected');
+
+  //   return new Promise((resolve, reject) => {
+  //     socket.emit('updatePlayerStatus', request, (error?: SocketError) => {
+  //       if (error) {
+  //         set({ error });
+  //         reject(error);
+  //       } else {
+  //         resolve();
+  //       }
+  //     });
+  //   });
+  // },
+
+  // updateSettings: async (request) => {
+  //   const socket = useSocketStore.getState().sockets.game;
+  //   if (!socket) throw new Error('Socket not connected');
+
+  //   return new Promise((resolve, reject) => {
+  //     socket.emit('updateSettings', request, (error?: SocketError) => {
+  //       if (error) {
+  //         set({ error });
+  //         reject(error);
+  //       } else {
+  //         resolve();
+  //       }
+  //     });
+  //   });
+  // },
+
+  // leaveRoom: async () => {
+  //   const socket = useSocketStore.getState().sockets.game;
+  //   if (!socket) throw new Error('Socket not connected');
+
+  //   return new Promise((resolve) => {
+  //     socket.emit('leaveRoom', () => {
+  //       get().actions.reset();
+  //       resolve();
+  //     });
+  //   });
+  // },
+};
+
+export type GameSocketHandlers = typeof gameSocketHandlers;

--- a/client/src/hooks/socket/useChatSocket.ts
+++ b/client/src/hooks/socket/useChatSocket.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { ChatResponse } from '@troublepainter/core';
 import { useParams } from 'react-router-dom';
-import { useChatStore } from '@/stores/socket/chatSocket.store';
+import { useChatSocketStore } from '@/stores/socket/chatSocket.store';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 import { SocketNamespace } from '@/stores/socket/socket.config';
 import { useSocketStore } from '@/stores/socket/socket.store';
@@ -31,8 +31,8 @@ import { useSocketStore } from '@/stores/socket/socket.store';
 export const useChatSocket = () => {
   const { roomId } = useParams<{ roomId: string }>();
   const { sockets, connected, actions: socketActions } = useSocketStore();
-  const { players, currentPlayerId } = useGameSocketStore();
-  const { messages, actions: chatActions } = useChatStore();
+  const { currentPlayerId } = useGameSocketStore();
+  const { messages, actions: chatActions } = useChatSocketStore();
 
   // Socket 연결 설정
   useEffect(() => {
@@ -65,32 +65,9 @@ export const useChatSocket = () => {
     };
   }, [sockets.chat, currentPlayerId, chatActions]);
 
-  // 메시지 전송
-  const sendMessage = useCallback(
-    (message: string) => {
-      const socket = sockets.chat;
-      if (!socket || !connected.chat || !message.trim() || !currentPlayerId) return;
-
-      const currentPlayer = players?.find((player) => player.playerId === currentPlayerId);
-      if (!currentPlayer) return;
-
-      const messageData: ChatResponse = {
-        playerId: currentPlayerId,
-        nickname: currentPlayer.nickname,
-        message: message.trim(),
-        createdAt: new Date().toISOString(),
-      };
-
-      chatActions.addMessage(messageData);
-      socket.emit('sendMessage', { message: message.trim() });
-    },
-    [sockets.chat, connected.chat, chatActions, currentPlayerId, players],
-  );
-
   return {
     messages,
     isConnected: connected.chat,
     currentPlayerId,
-    sendMessage,
   };
 };

--- a/client/src/hooks/socket/useDrawingSocket.ts
+++ b/client/src/hooks/socket/useDrawingSocket.ts
@@ -1,9 +1,8 @@
 // 이벤트 중심적 구조, 드로잉 관련 단일 책임, 실시간 드로잉 데이터
 // 특정 기능(드로잉)에 집중된 이벤트 핸들링
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import type { DrawUpdateResponse } from '@troublepainter/core';
-import type { DrawingData } from '@troublepainter/core';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 import { SocketNamespace } from '@/stores/socket/socket.config';
 import { useSocketStore } from '@/stores/socket/socket.store';
@@ -98,19 +97,7 @@ export const useDrawingSocket = ({ onDrawUpdate }: UseDrawingSocketProps = {}) =
     };
   }, [sockets.drawing, currentPlayerId, onDrawUpdate]);
 
-  // 드로잉 데이터 전송
-  const sendDrawing = useCallback(
-    (drawingData: DrawingData) => {
-      const socket = sockets.drawing;
-      if (!socket || !connected.drawing) return;
-
-      socket.emit('draw', { drawingData });
-    },
-    [sockets.drawing, connected.drawing],
-  );
-
   return {
     isConnected: connected.drawing,
-    sendDrawing,
   };
 };

--- a/client/src/hooks/socket/useGameSocket.ts
+++ b/client/src/hooks/socket/useGameSocket.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import type { JoinRoomResponse, PlayerLeftResponse } from '@troublepainter/core';
+import { gameSocketHandlers } from '@/handlers/socket/gameSocket.handler';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 import { SocketNamespace } from '@/stores/socket/socket.config';
 import { useSocketStore } from '@/stores/socket/socket.store';
@@ -75,7 +76,7 @@ export const useGameSocket = () => {
     const savedPlayerId = playerIdStorageUtils.getPlayerId(roomId);
     // console.log(savedPlayerId, roomId);
     if (savedPlayerId) {
-      gameActions.reconnect({ playerId: savedPlayerId, roomId }).catch((error) => {
+      gameSocketHandlers.reconnect({ playerId: savedPlayerId, roomId }).catch((error) => {
         // 재연결 실패 시 계정 삭제
         console.error('Reconnection failed:', error);
         playerIdStorageUtils.removePlayerId(roomId);
@@ -84,7 +85,7 @@ export const useGameSocket = () => {
     // savedPlayerId가 없다면 새로운 접속 시도
     else {
       playerIdStorageUtils.removeAllPlayerIds();
-      gameActions.joinRoom({ roomId }).catch(console.error);
+      gameSocketHandlers.joinRoom({ roomId }).catch(console.error);
     }
 
     // 연결 해제 시 현재 방의 playerId만 제거

--- a/client/src/pages/ExamplePageCanvasOnly.tsx
+++ b/client/src/pages/ExamplePageCanvasOnly.tsx
@@ -1,5 +1,5 @@
 import { PlayerRole } from '@troublepainter/core';
-import { GameCanvas } from '@/components/canvas/GameCanvasExample';
+import { GameCanvas } from '@/components/canvas/GameCanvas';
 
 const ExamplePageCanvasOnly = () => {
   return (

--- a/client/src/pages/GameRoomPage.tsx
+++ b/client/src/pages/GameRoomPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { PlayerRole } from '@troublepainter/core';
-import { GameCanvas } from '@/components/canvas/GameCanvasExample';
+import { GameCanvas } from '@/components/canvas/GameCanvas';
 import { QuizTitle } from '@/components/ui/QuizTitle';
 
 const GameRoomPage = () => {

--- a/client/src/stores/socket/chatSocket.store.ts
+++ b/client/src/stores/socket/chatSocket.store.ts
@@ -6,16 +6,16 @@ export interface ChatState {
   messages: ChatResponse[];
 }
 
-export interface ChatStore extends ChatState {
+const initialState: ChatState = {
+  messages: [],
+};
+
+export interface ChatStore {
   actions: {
     addMessage: (message: ChatResponse) => void;
     clearMessages: () => void;
   };
 }
-
-const initialState: ChatState = {
-  messages: [],
-};
 
 /**
  * 채팅 상태와 액션을 관리하는 ㄴtore입니다.
@@ -25,12 +25,11 @@ const initialState: ChatState = {
  *
  * @example
  * ```typescript
- * const { messages, actions } = useChatStore();
+ * const { messages, actions } = useChatSocketStore();
  * actions.addMessage(newMessage);
  * ```
  */
-
-export const useChatStore = create<ChatStore>()(
+export const useChatSocketStore = create<ChatState & ChatStore>()(
   devtools(
     (set) => ({
       ...initialState,


### PR DESCRIPTION
## 📂 작업 내용
closes #105
- [x] socket 관련 코드 구조 개선
  - 웹소켓 요청 핸들러 분리 (게임/드로잉/채팅)
  - 상태 관리와 소켓 통신 로직 분리
  - 커스텀 훅에서 핸들러 사용하도록 변경

## 💡 자세한 설명
- Socket 관련 코드를 다음과 같이 리팩토링
  1. `handlers/socket`: 순수 웹소켓 요청 처리
  2. `stores/socket`: 순수 상태 관리
  3. `hooks/socket`: 소켓 연결 / 이벤트 구독 관리

- 기대 효과
  - 코드 재사용성 향상
  - 관심사 분리로 인한 유지보수성 개선
  - 테스트 용이성 향상
  - Promise 기반의 일관된 에러 처리

## 🚩 후속 작업
- 에러 처리 로직 개선

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?