### PR TITLE
feat: Add round timer functionality

### DIFF
--- a/server/src/common/enums/game.status.enum.ts
+++ b/server/src/common/enums/game.status.enum.ts
@@ -11,5 +11,6 @@ export enum PlayerRole {
 
 export enum RoomStatus {
   WAITING = 'WAITING',
-  IN_GAME = 'IN_GAME',
+  DRAWING = 'DRAWING',
+  GUESSING = 'GUESSING',
 }

--- a/server/src/common/services/timer.service.ts
+++ b/server/src/common/services/timer.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+import { Server } from 'socket.io';
+
+interface TimerCallbacks {
+  onTick: (remaining: number) => void;
+  onTimeUp: () => void;
+}
+
+@Injectable()
+export class TimerService {
+  private timers = new Map<string, { intervalId: NodeJS.Timeout; endTime: number; duration: number }>();
+
+  constructor() {}
+
+  startTimer(server: Server, roomId: string, duration: number, callbacks: TimerCallbacks) {
+    this.stopGameTimer(roomId);
+
+    const startTime = Date.now();
+    const endTime = startTime + duration;
+
+    const intervalId = setInterval(() => {
+      const now = Date.now();
+      const remaining = Math.max(0, endTime - now);
+
+      callbacks.onTick(remaining);
+
+      if (remaining === 0) {
+        this.stopGameTimer(roomId);
+        callbacks.onTimeUp();
+      }
+    }, 5000);
+
+    this.timers.set(roomId, {
+      intervalId,
+      endTime,
+      duration,
+    });
+  }
+
+  stopGameTimer(roomId: string) {
+    const timer = this.timers.get(roomId);
+
+    if (timer) {
+      clearInterval(timer.intervalId);
+      this.timers.delete(roomId);
+    }
+  }
+
+  getRemainingTime(roomId: string) {
+    const timer = this.timers.get(roomId);
+    if (!timer) return 0;
+
+    return Math.max(0, timer.endTime - Date.now());
+  }
+
+  clearAllTimers() {
+    this.timers.forEach((timer) => {
+      clearInterval(timer.intervalId);
+    });
+    this.timers.clear();
+  }
+}

--- a/server/src/game/game.module.ts
+++ b/server/src/game/game.module.ts
@@ -4,10 +4,11 @@ import { GameController } from './game.controller';
 import { GameGateway } from './game.gateway';
 import { RedisModule } from 'src/redis/redis.module';
 import { GameRepository } from './game.repository';
+import { TimerService } from 'src/common/services/timer.service';
 
 @Module({
   imports: [RedisModule],
-  providers: [GameService, GameGateway, GameRepository],
+  providers: [GameService, GameGateway, GameRepository, TimerService],
   controllers: [GameController],
 })
 export class GameModule {}

--- a/server/src/game/game.service.ts
+++ b/server/src/game/game.service.ts
@@ -16,7 +16,7 @@ export class GameService {
   private readonly DEFAULT_ROOM_SETTINGS: RoomSettings = {
     maxPlayers: 5,
     totalRounds: 5,
-    drawTime: 30,
+    drawTime: 35,
   };
 
   constructor(private readonly gameRepository: GameRepository) {}
@@ -139,7 +139,7 @@ export class GameService {
     const roomSettings = await this.gameRepository.getRoomSettings(roomId);
 
     const roomUpdates = {
-      status: RoomStatus.IN_GAME,
+      status: RoomStatus.DRAWING,
       currentRound: room.currentRound + 1,
       currentWord: '바보',
     };


### PR DESCRIPTION
## 📂 작업 내용

closes #112 

- [x] 30초 타이머 로직 구현

## 💡 자세한 설명

- 게임 라운드 타이머를 관리하기 위한 TimerService 추가
- 시간 동기화를 위해 5초 간격의 동기화 인터벌 구현
- 게임 게이트웨이에서 타이머 이벤트 처리 (동기화, 종료)
- 방이 비어 있으면 타이머를 정리

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
