### PR TITLE
feat: Implement game start logic and role distribution

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,17 +1,16 @@
 <!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/gh/neodgm/neodgm-pro-webfont@latest/neodgm_pro/style.css" />
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Vite + React + TS</title>
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/gh/neodgm/neodgm-pro-webfont@latest/neodgm_pro/style.css">
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <div id="modal-root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,13 +21,7 @@ const AppProvider = ({ children }: AppChildrenProps) => {
 
 // ErrorBoundary, 모달 등 추가할 예정
 const App = ({ children }: AppChildrenProps) => {
-  return (
-    <AppProvider>
-      {children}
-      {/* 모달을 위한 포털 */}
-      {/* <div id="modal-root" />  */}
-    </AppProvider>
-  );
+  return <AppProvider>{children}</AppProvider>;
 };
 
 export default App;

--- a/client/src/components/modal/RoleModal.tsx
+++ b/client/src/components/modal/RoleModal.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { Modal } from '@/components/ui/Modal';
+import { PLAYING_ROLE_TEXT } from '@/constants/gameConstant';
+import { useModal } from '@/hooks/useModal';
+import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
+
+const RoleModal = () => {
+  const { players, currentPlayerId, room } = useGameSocketStore();
+  const { isModalOpened, closeModal, handleKeyDown, openModal } = useModal(3000);
+
+  const myRole = players.find((player) => player.playerId === currentPlayerId)?.role || null;
+
+  if (!myRole) return null;
+
+  useEffect(() => {
+    if (myRole) openModal();
+  }, [myRole, room?.currentRound]);
+
+  return (
+    <Modal
+      title="역할 배정"
+      isModalOpened={isModalOpened}
+      closeModal={closeModal}
+      handleKeyDown={handleKeyDown}
+      className="w-80"
+    >
+      <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">
+        {PLAYING_ROLE_TEXT[myRole]}
+      </span>
+    </Modal>
+  );
+};
+
+export default RoleModal;

--- a/client/src/components/player/PlayerCardList.tsx
+++ b/client/src/components/player/PlayerCardList.tsx
@@ -1,23 +1,35 @@
+import { PlayerRole } from '@troublepainter/core';
 import { PlayerCard } from '@/components/ui/PlayerCard';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 
 const PlayerCardList = () => {
-  const { players, room } = useGameSocketStore();
+  const { players, room, currentPlayerId } = useGameSocketStore();
 
   if (!players?.length) return null;
 
+  const myRole = players.find((player) => player.playerId === currentPlayerId)?.role || undefined;
+
+  const getPlayerRole = (playerRole: PlayerRole | undefined, myRole: PlayerRole | undefined) => {
+    if (myRole === PlayerRole.GUESSER) return playerRole === PlayerRole.GUESSER ? playerRole : null;
+    return playerRole;
+  };
+
   return (
     <>
-      {players.map((player) => (
-        <PlayerCard
-          key={player.playerId}
-          nickname={player.nickname}
-          status={player.status}
-          role={player.role}
-          score={player.score}
-          isHost={player.playerId === room?.hostId}
-        />
-      ))}
+      {players.map((player) => {
+        const playerRole = getPlayerRole(player.role, myRole) || null;
+
+        return (
+          <PlayerCard
+            key={player.playerId}
+            nickname={player.nickname}
+            status={player.status}
+            role={playerRole}
+            score={player.score}
+            isHost={player.playerId === room?.hostId}
+          />
+        );
+      })}
     </>
   );
 };

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
 import { HTMLAttributes, KeyboardEvent, PropsWithChildren } from 'react';
+import ReactDOM from 'react-dom'; // Import ReactDOM explicitly
 import { cn } from '@/utils/cn';
 
 export interface ModalProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
@@ -9,7 +10,11 @@ export interface ModalProps extends PropsWithChildren<HTMLAttributes<HTMLDivElem
 }
 
 const Modal = ({ className, handleKeyDown, closeModal, isModalOpened, title, children, ...props }: ModalProps) => {
-  return (
+  const modalRoot = document.getElementById('modal-root');
+
+  if (!modalRoot) return null;
+
+  return ReactDOM.createPortal(
     <div
       className={cn(
         'fixed left-0 top-0 flex h-full w-full items-center justify-center',
@@ -43,7 +48,8 @@ const Modal = ({ className, handleKeyDown, closeModal, isModalOpened, title, chi
         </div>
         <div className="p-5">{children}</div>
       </div>
-    </div>
+    </div>,
+    modalRoot,
   );
 };
 

--- a/client/src/components/ui/PlayerCard.tsx
+++ b/client/src/components/ui/PlayerCard.tsx
@@ -1,6 +1,7 @@
 import { PlayerRole } from '@troublepainter/core';
 import { cva, type VariantProps } from 'class-variance-authority';
 import profilePlaceholder from '@/assets/profile-placeholder.png';
+import { PLAYING_ROLE_TEXT } from '@/constants/gameConstant';
 import { cn } from '@/utils/cn';
 import getCrownImage from '@/utils/getCrownImage';
 
@@ -65,6 +66,7 @@ interface PlayerCardProps extends VariantProps<typeof playerCardVariants> {
  *   status="gaming"
  * />
  */
+
 const PlayerCard = ({
   nickname,
   rank,
@@ -140,7 +142,7 @@ const PlayerCard = ({
           </div>
           <div className="h-3 text-stroke-sm lg:h-auto">
             <div
-              title={role || '???'}
+              title={role ? PLAYING_ROLE_TEXT[role] : '???'}
               className={cn(
                 // 기본 & 모바일 스타일
                 'w-20 truncate text-[0.625rem] text-gray-50',
@@ -150,7 +152,7 @@ const PlayerCard = ({
                 '2xl:max-w-52',
               )}
             >
-              {role || '???'}
+              {role ? PLAYING_ROLE_TEXT[role] : '???'}
             </div>
           </div>
         </div>

--- a/client/src/constants/gameConstant.ts
+++ b/client/src/constants/gameConstant.ts
@@ -1,0 +1,8 @@
+import { PlayerRole } from '@troublepainter/core';
+import { PlayingRoleText } from '@/types/game.types';
+
+export const PLAYING_ROLE_TEXT: Record<PlayerRole, PlayingRoleText> = {
+  [PlayerRole.DEVIL]: '방해꾼',
+  [PlayerRole.GUESSER]: '구경꾼',
+  [PlayerRole.PAINTER]: '그림꾼',
+};

--- a/client/src/handlers/socket/gameSocket.handler.ts
+++ b/client/src/handlers/socket/gameSocket.handler.ts
@@ -21,12 +21,22 @@ export const gameSocketHandlers = {
     });
   },
 
-  updateSettings: async (request: UpdateSettingsRequest): Promise<void> => {
+  updateSettings: (request: UpdateSettingsRequest): Promise<void> => {
     const socket = useSocketStore.getState().sockets.game;
     if (!socket) throw new Error('Socket not connected');
 
     return new Promise((resolve) => {
       socket.emit('updateSettings', request);
+      resolve();
+    });
+  },
+
+  gameStart: (request: { roomId: string; playerId: string }): Promise<void> => {
+    const socket = useSocketStore.getState().sockets.game;
+    if (!socket) throw new Error('Socket not connected');
+
+    return new Promise((resolve) => {
+      socket.emit('gameStart', request);
       resolve();
     });
   },
@@ -37,22 +47,6 @@ export const gameSocketHandlers = {
 
   //   return new Promise((resolve, reject) => {
   //     socket.emit('updatePlayerStatus', request, (error?: SocketError) => {
-  //       if (error) {
-  //         set({ error });
-  //         reject(error);
-  //       } else {
-  //         resolve();
-  //       }
-  //     });
-  //   });
-  // },
-
-  // updateSettings: async (request) => {
-  //   const socket = useSocketStore.getState().sockets.game;
-  //   if (!socket) throw new Error('Socket not connected');
-
-  //   return new Promise((resolve, reject) => {
-  //     socket.emit('updateSettings', request, (error?: SocketError) => {
   //       if (error) {
   //         set({ error });
   //         reject(error);

--- a/client/src/pages/GameRoomPage.tsx
+++ b/client/src/pages/GameRoomPage.tsx
@@ -1,40 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { PlayerRole } from '@troublepainter/core';
 import { GameCanvas } from '@/components/canvas/GameCanvas';
-import { Modal } from '@/components/ui/Modal';
+import RoleModal from '@/components/modal/RoleModal';
 import { QuizTitle } from '@/components/ui/QuizTitle';
-import { PLAYING_ROLE_TEXT } from '@/constants/gameConstant';
-import { useModal } from '@/hooks/useModal';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 
 const GameRoomPage = () => {
   const [remainingTime] = useState(30);
-  const { isModalOpened, closeModal, handleKeyDown, openModal } = useModal(3000);
   const { players, currentPlayerId, room, roomSettings } = useGameSocketStore();
 
-  const myRole = players.find((player) => player.playerId === currentPlayerId)?.role || null;
-
-  useEffect(() => {
-    if (myRole) openModal();
-  }, [myRole, room?.currentRound]);
-
-  if (!room || !players || !currentPlayerId || !roomSettings || !myRole) return null;
+  if (!room || !players || !currentPlayerId || !roomSettings) return null;
 
   return (
     <>
-      {/* 역할 모달 */}
-      <Modal
-        title="역할 배정"
-        isModalOpened={isModalOpened}
-        closeModal={closeModal}
-        handleKeyDown={handleKeyDown}
-        className="w-80"
-      >
-        <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">
-          {PLAYING_ROLE_TEXT[myRole]}
-        </span>
-      </Modal>
-
+      <RoleModal />
       {/* 중앙 영역 - 게임 화면 */}
       <QuizTitle
         currentRound={room.currentRound}

--- a/client/src/pages/GameRoomPage.tsx
+++ b/client/src/pages/GameRoomPage.tsx
@@ -1,15 +1,47 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { PlayerRole } from '@troublepainter/core';
 import { GameCanvas } from '@/components/canvas/GameCanvas';
+import { Modal } from '@/components/ui/Modal';
 import { QuizTitle } from '@/components/ui/QuizTitle';
+import { PLAYING_ROLE_TEXT } from '@/constants/gameConstant';
+import { useModal } from '@/hooks/useModal';
+import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 
 const GameRoomPage = () => {
   const [remainingTime] = useState(30);
+  const { isModalOpened, closeModal, handleKeyDown, openModal } = useModal(3000);
+  const { players, currentPlayerId, room, roomSettings } = useGameSocketStore();
+
+  const myRole = players.find((player) => player.playerId === currentPlayerId)?.role || null;
+
+  useEffect(() => {
+    if (myRole) openModal();
+  }, [myRole, room?.currentRound]);
+
+  if (!room || !players || !currentPlayerId || !roomSettings || !myRole) return null;
 
   return (
     <>
+      {/* 역할 모달 */}
+      <Modal
+        title="역할 배정"
+        isModalOpened={isModalOpened}
+        closeModal={closeModal}
+        handleKeyDown={handleKeyDown}
+        className="w-80"
+      >
+        <span className="flex min-h-28 items-center justify-center text-3xl text-violet-950">
+          {PLAYING_ROLE_TEXT[myRole]}
+        </span>
+      </Modal>
+
       {/* 중앙 영역 - 게임 화면 */}
-      <QuizTitle currentRound={1} totalRound={4} title="뭘까요?뭘까요?뭘까요?뭘까요?" remainingTime={remainingTime} />
+      <QuizTitle
+        currentRound={room.currentRound}
+        totalRound={roomSettings.totalRounds}
+        title="뭘까요?뭘까요?뭘까요?뭘까요?"
+        remainingTime={remainingTime}
+      />
       <GameCanvas role={PlayerRole.PAINTER} maxPixels={100000} />
     </>
   );

--- a/client/src/pages/LobbyPage.tsx
+++ b/client/src/pages/LobbyPage.tsx
@@ -1,16 +1,19 @@
 import { useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { Setting } from '@/components/setting/Setting';
 import { Button } from '@/components/ui/Button';
+import { gameSocketHandlers } from '@/handlers/socket/gameSocket.handler';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 import { cn } from '@/utils/cn';
 
 const LobbyPage = () => {
   const { roomId } = useParams<{ roomId: string }>();
-  const navigate = useNavigate();
   const { players, room, currentPlayerId } = useGameSocketStore();
+
   // 현재 사용자가 방장인지 확인
   const isHost = useMemo(() => room?.hostId === currentPlayerId, [room?.hostId, currentPlayerId]);
+
+  //console.log(players, room);
 
   const buttonConfig = useMemo(() => {
     if (!isHost) return START_BUTTON_STATUS.NOT_HOST;
@@ -19,8 +22,8 @@ const LobbyPage = () => {
   }, [isHost, players.length]);
 
   const handleStartGame = () => {
-    if (buttonConfig.disabled || !roomId) return;
-    navigate(`/game/${roomId}`);
+    if (buttonConfig.disabled || !roomId || !currentPlayerId) return;
+    void gameSocketHandlers.gameStart({ roomId: roomId, playerId: currentPlayerId });
   };
 
   return (
@@ -30,10 +33,6 @@ const LobbyPage = () => {
         <p className="mb-3 text-center text-xl text-eastbay-50 text-stroke-md sm:mb-0 sm:text-2xl lg:text-3xl">
           Get Ready for the next battle
         </p>
-
-        <Button onClick={() => navigate(`/game/${roomId}`)} variant={'secondary'}>
-          테스트 게임 시작
-        </Button>
 
         <Setting type={isHost ? 'host' : 'participant'} />
         <div className="flex h-11 w-full gap-0 sm:h-14 sm:gap-8">

--- a/client/src/stores/socket/gameSocket.store.ts
+++ b/client/src/stores/socket/gameSocket.store.ts
@@ -1,4 +1,4 @@
-import { Player, Room, RoomSettings } from '@troublepainter/core';
+import { Player, PlayerRole, Room, RoomSettings } from '@troublepainter/core';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
@@ -11,11 +11,21 @@ interface GameState {
 
 interface GameActions {
   // 상태 업데이트 액션
+
+  // room 상태 업데이트
   updateRoom: (room: Room) => void;
+  updateCurrentRound: (currentRound: number) => void;
+  updateCurrentWord: (currentWord: string) => void;
+
+  // roomSetting 상태 업데이트
   updateRoomSettings: (settings: RoomSettings) => void;
+
+  //player 상태 업데이트
   updatePlayers: (players: Player[]) => void;
-  updateCurrentPlayerId: (currentPlayerId: string) => void;
   removePlayer: (playerId: string) => void;
+  updatePlayerRole: (playerId: string, role: PlayerRole) => void;
+
+  updateCurrentPlayerId: (currentPlayerId: string) => void;
 
   // 상태 초기화
   reset: () => void;
@@ -64,6 +74,18 @@ export const useGameSocketStore = create<GameState & { actions: GameActions }>()
           set({ room });
         },
 
+        updateCurrentRound: (currentRound) => {
+          set((state) => ({
+            room: state.room && { ...state.room, currentRound },
+          }));
+        },
+
+        updateCurrentWord: (currentWord) => {
+          set((state) => ({
+            room: state.room && { ...state.room, currentWord },
+          }));
+        },
+
         updateRoomSettings: (settings) => {
           set({ roomSettings: settings });
         },
@@ -79,6 +101,12 @@ export const useGameSocketStore = create<GameState & { actions: GameActions }>()
         removePlayer: (playerId) => {
           set((state) => ({
             players: state.players.filter((player) => player.playerId !== playerId),
+          }));
+        },
+
+        updatePlayerRole: (playerId, role) => {
+          set((state) => ({
+            players: state.players.map((player) => (player.playerId === playerId ? { ...player, role } : player)),
           }));
         },
 

--- a/client/src/types/game.types.ts
+++ b/client/src/types/game.types.ts
@@ -1,0 +1,1 @@
+export type PlayingRoleText = '그림꾼' | '방해꾼' | '구경꾼';

--- a/core/types/game.types.ts
+++ b/core/types/game.types.ts
@@ -10,10 +10,8 @@ export interface Player {
 export interface Room {
   roomId?: string; // 서버는 필요없음
   hostId: string;
-  settings: RoomSettings;
   status: RoomStatus;
   currentRound: number;
-  totalRounds: number;
   currentWord?: string;
 }
 
@@ -21,19 +19,19 @@ export interface RoomSettings {
   maxPlayers: number; // 최대 플레이어 수
   drawTime: number; // 그리기 제한시간
   totalRounds: number; // 총 라운드 수
-  maxPixels: number; // 그리기 제한 픽셀
 }
 
 export enum PlayerStatus {
-  NOT_PLAYING = 'NOT_PLAYING',
-  PLAYING = 'PLAYING',
+  NOT_PLAYING = "NOT_PLAYING",
+  PLAYING = "PLAYING",
 }
 export enum PlayerRole {
-  PAINTER = 'PAINTER',
-  DEVIL = 'DEVIL',
-  GUESSER = 'GUESSER',
+  PAINTER = "PAINTER",
+  DEVIL = "DEVIL",
+  GUESSER = "GUESSER",
 }
 export enum RoomStatus {
-  WAITING = 'WAITING',
-  IN_GAME = 'IN_GAME',
+  WAITING = "WAITING",
+  DRAWING = "DRAWING",
+  GUESSING = "GUESSING",
 }


### PR DESCRIPTION
## 📂 작업 내용

closes #110 

- [x] socket을 통해 역할을 받습니다.
- [x] 역할 모달을 3초동안 띄웁니다.
- [x] 모달은 사용자가 임의로 닫을 수 있습니다.
- [x] 부여받은 role대로 왼쪽 player 부분에도 띄워줍니다.
- [x] player 부분에 본인이 구경꾼이면 그림꾼/방해꾼을 물음표(???)로 띄웁니다.
- [x] player 부분에 본인이 그림꾼이나 방해꾼이면 역할을 정상적으로 띄웁니다.

## 💡 자세한 설명

### 1. 모달 띄우는 위치 변경
기존 모달은 root 아래에 띄워졌다면, root아 아예 분리된 modal-root에서 모달이 띄워지도록 수정하였습니다.
모달은 페이지의 콘텐츠와 독립적으로 렌더링되어야 하기 때문입니다. 또한 분리함으로써 UI 및 기능적으로 독립적으로 유지할 수 있고, 모달이 트리 구조나 스타일, 레이아웃에 끼치는 영향을 최소화할 수 있습니다.
```js
// index.html
<div id="root"></div>
<div id="modal-root"></div>
```

### 2. 게임 시작 트리거 및 역할 배정
방장 && 플레이어 수가 4명 이상일 때만 게임 시작 버튼이 활성화되며, 방장이 게임 시작 버튼을 누르면 gameStart 이벤트를 발생시킵니다.

구경꾼일 때는 구경꾼인 player의 id만 받아서 전역 저장소(player)에 저장해주고, 그림꾼이나 방해꾼일 때는 모든 player의 id와 role을 받아서 전역 저장소(player)에 저장해줍니다. 

## 📗 참고 자료 & 구현 결과 (선택)

![kkkkkk](https://github.com/user-attachments/assets/d76d33b6-76d8-4b7b-83ea-2e3a03844033)


## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
