### PR TITLE
fix: Fix undo/redo functionality issues during CRDT integration

### DIFF
--- a/client/src/hooks/useDrawing.ts
+++ b/client/src/hooks/useDrawing.ts
@@ -110,9 +110,9 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
 
   // CRDT 및 히스토리 관리
   const crdtRef = useRef<LWWMap>();
+  const currentStrokeIds = useRef<string[]>([]);
   const strokeHistoryRef = useRef<StrokeHistoryEntry[]>([]);
   const historyPointerRef = useRef<number>(-1);
-  const currentSessionStrokeIds = useRef<string[]>([]);
 
   const getCurrentStyle = useCallback((): StrokeStyle => {
     return {
@@ -237,7 +237,7 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
       if (inkRemaining <= 0 || !crdtRef.current) return null;
 
       // 새로운 드로잉 세션 시작
-      currentSessionStrokeIds.current = [];
+      currentStrokeIds.current = [];
 
       const drawingData =
         drawingMode === DRAWING_MODE.FILL
@@ -250,7 +250,7 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
       if (!drawingData) return null;
 
       const strokeId = crdtRef.current.addStroke(drawingData);
-      currentSessionStrokeIds.current.push(strokeId);
+      currentStrokeIds.current.push(strokeId);
       drawStroke(drawingData);
 
       return {
@@ -269,7 +269,7 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
       if (!crdtRef.current || inkRemaining <= 0) return null;
       if (drawingMode === DRAWING_MODE.FILL) return null;
 
-      const lastStrokeId = currentSessionStrokeIds.current[currentSessionStrokeIds.current.length - 1];
+      const lastStrokeId = currentStrokeIds.current[currentStrokeIds.current.length - 1];
       const lastStroke = crdtRef.current.strokes.find((s) => s.id === lastStrokeId);
       if (!lastStroke) return null;
 
@@ -286,7 +286,7 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
       setInkRemaining((prev) => Math.max(0, prev - pixelsUsed));
 
       const strokeId = crdtRef.current.addStroke(updatedDrawing);
-      currentSessionStrokeIds.current.push(strokeId);
+      currentStrokeIds.current.push(strokeId);
       drawStroke(updatedDrawing);
 
       return {
@@ -301,7 +301,7 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
   );
 
   const stopDrawing = useCallback(() => {
-    if (!crdtRef.current || currentSessionStrokeIds.current.length === 0) return;
+    if (!crdtRef.current || currentStrokeIds.current.length === 0) return;
 
     // 새로운 stroke가 추가되면 redo 히스토리를 비움
     if (historyPointerRef.current < strokeHistoryRef.current.length - 1) {
@@ -309,21 +309,21 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
     }
 
     // 현재 세션의 마지막 stroke 가져오기
-    const lastStrokeId = currentSessionStrokeIds.current[currentSessionStrokeIds.current.length - 1];
+    const lastStrokeId = currentStrokeIds.current[currentStrokeIds.current.length - 1];
     const lastStroke = crdtRef.current.strokes.find((s) => s.id === lastStrokeId);
 
     if (!lastStroke) return;
 
     // 현재 세션의 모든 stroke를 하나의 히스토리 엔트리로 저장
     strokeHistoryRef.current.push({
-      strokeIds: [...currentSessionStrokeIds.current],
+      strokeIds: [...currentStrokeIds.current],
       isLocal: true,
       drawingData: lastStroke.stroke,
     });
     historyPointerRef.current = strokeHistoryRef.current.length - 1;
 
     // 현재 세션 초기화
-    currentSessionStrokeIds.current = [];
+    currentStrokeIds.current = [];
     updateHistoryState();
   }, [updateHistoryState]);
 

--- a/client/src/hooks/useDrawing.ts
+++ b/client/src/hooks/useDrawing.ts
@@ -221,10 +221,14 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
   // 히스토리 상태 업데이트
   const updateHistoryState = useCallback(() => {
     const localHistory = strokeHistoryRef.current.filter((entry) => entry.isLocal);
-    const currentIndex = historyPointerRef.current;
 
-    setCanUndo(localHistory.slice(0, currentIndex + 1).length > 0);
-    setCanRedo(localHistory.slice(currentIndex + 1).length > 0);
+    // 전체 히스토리에서 현재 포인터까지의 로컬 항목 개수를 세기
+    const localItemsCount = strokeHistoryRef.current
+      .slice(0, historyPointerRef.current + 1)
+      .filter((entry) => entry.isLocal).length;
+
+    setCanUndo(localItemsCount > 0);
+    setCanRedo(localItemsCount < localHistory.length);
   }, []);
 
   // 드로잉 시작

--- a/client/src/hooks/useDrawing.ts
+++ b/client/src/hooks/useDrawing.ts
@@ -42,7 +42,10 @@ const checkColorisNotEqual = (pos: number, startColor: RGBA, pixelArray: Uint8Cl
  * - 펜/채우기 모드 드로잉
  * - 실행 취소/다시 실행
  * - 잉크 잔량 관리
- * - 드로잉 데이터 기록 및 재생
+ * - 실시간 드로잉 데이터 동기화 및 기록
+ *
+ * 드로잉은 mousedown부터 mouseup까지를 하나의 단위로 처리하며,
+ * 실시간으론 각 stroke 단위로 동기화하고 히스토리는 mouseup 단위로 기록됩니다.
  *
  * @param canvasRef - 캔버스 엘리먼트의 RefObject
  * @param options - 드로잉 설정 옵션
@@ -88,11 +91,12 @@ const checkColorisNotEqual = (pos: number, startColor: RGBA, pixelArray: Uint8Cl
  * - `brushSize` - 현재 브러시 크기
  * - `drawingMode` - 현재 드로잉 모드 (펜/채우기)
  * - `inkRemaining` - 남은 잉크량
- * - `startDrawing` - 드로잉 시작 함수
- * - `draw` - 드로잉 진행 함수
- * - `stopDrawing` - 드로잉 종료 함수
+ * - `startDrawing` - 드로잉 시작 함수 (mousedown)
+ * - `draw` - 드로잉 진행 함수 (mousemove)
+ * - `stopDrawing` - 드로잉 종료 함수 (mouseup)
  * - `applyDrawing` - 외부 드로잉 데이터 적용 함수
- * - `undo/redo` - 실행 취소/다시 실행 함수
+ * - `undo/redo` - mouseup 단위로 실행 취소/다시 실행하는 함수
+ * - `canUndo/canRedo` - 실행 취소/다시 실행 가능 여부
  *
  * @category Hooks
  */
@@ -110,8 +114,9 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
 
   // CRDT 및 히스토리 관리
   const crdtRef = useRef<LWWMap>();
-  const currentStrokeIds = useRef<string[]>([]);
   const strokeHistoryRef = useRef<StrokeHistoryEntry[]>([]);
+  // mouseup 전까지 발생한 모든 점들의 stroke ID를 담고 있는 배열
+  const currentStrokeIdsRef = useRef<string[]>([]);
   const historyPointerRef = useRef<number>(-1);
 
   const getCurrentStyle = useCallback((): StrokeStyle => {
@@ -236,8 +241,8 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
     (point: Point): CRDTMessage | null => {
       if (inkRemaining <= 0 || !crdtRef.current) return null;
 
-      // 새로운 드로잉 세션 시작
-      currentStrokeIds.current = [];
+      // 새로운 currentStrokeIdsRef 시작
+      currentStrokeIdsRef.current = [];
 
       const drawingData =
         drawingMode === DRAWING_MODE.FILL
@@ -250,7 +255,7 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
       if (!drawingData) return null;
 
       const strokeId = crdtRef.current.addStroke(drawingData);
-      currentStrokeIds.current.push(strokeId);
+      currentStrokeIdsRef.current.push(strokeId);
       drawStroke(drawingData);
 
       return {
@@ -267,9 +272,10 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
   const draw = useCallback(
     (point: Point): CRDTMessage | null => {
       if (!crdtRef.current || inkRemaining <= 0) return null;
+      // Fill 모드에서는 draw 동작 없음
       if (drawingMode === DRAWING_MODE.FILL) return null;
 
-      const lastStrokeId = currentStrokeIds.current[currentStrokeIds.current.length - 1];
+      const lastStrokeId = currentStrokeIdsRef.current[currentStrokeIdsRef.current.length - 1];
       const lastStroke = crdtRef.current.strokes.find((s) => s.id === lastStrokeId);
       if (!lastStroke) return null;
 
@@ -286,7 +292,7 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
       setInkRemaining((prev) => Math.max(0, prev - pixelsUsed));
 
       const strokeId = crdtRef.current.addStroke(updatedDrawing);
-      currentStrokeIds.current.push(strokeId);
+      currentStrokeIdsRef.current.push(strokeId);
       drawStroke(updatedDrawing);
 
       return {
@@ -301,29 +307,29 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
   );
 
   const stopDrawing = useCallback(() => {
-    if (!crdtRef.current || currentStrokeIds.current.length === 0) return;
+    if (!crdtRef.current || currentStrokeIdsRef.current.length === 0) return;
 
     // 새로운 stroke가 추가되면 redo 히스토리를 비움
     if (historyPointerRef.current < strokeHistoryRef.current.length - 1) {
       strokeHistoryRef.current = strokeHistoryRef.current.slice(0, historyPointerRef.current + 1);
     }
 
-    // 현재 세션의 마지막 stroke 가져오기
-    const lastStrokeId = currentStrokeIds.current[currentStrokeIds.current.length - 1];
+    // 현재 currentStrokeIdsRef의 마지막 stroke 가져오기
+    const lastStrokeId = currentStrokeIdsRef.current[currentStrokeIdsRef.current.length - 1];
     const lastStroke = crdtRef.current.strokes.find((s) => s.id === lastStrokeId);
 
     if (!lastStroke) return;
 
-    // 현재 세션의 모든 stroke를 하나의 히스토리 엔트리로 저장
+    // 현재 currentStrokeIdsRef의 모든 stroke를 하나의 히스토리 엔트리로 저장
     strokeHistoryRef.current.push({
-      strokeIds: [...currentStrokeIds.current],
+      strokeIds: [...currentStrokeIdsRef.current],
       isLocal: true,
       drawingData: lastStroke.stroke,
     });
     historyPointerRef.current = strokeHistoryRef.current.length - 1;
 
-    // 현재 세션 초기화
-    currentStrokeIds.current = [];
+    // 현재 currentStrokeIdsRef 초기화
+    currentStrokeIdsRef.current = [];
     updateHistoryState();
   }, [updateHistoryState]);
 
@@ -387,6 +393,7 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
   const undo = useCallback(() => {
     if (!crdtRef.current || historyPointerRef.current < 0) return null;
 
+    // 현재 포인터부터 로컬 엔트리 찾기
     let currentEntry = strokeHistoryRef.current[historyPointerRef.current];
     while (currentEntry && !currentEntry.isLocal && historyPointerRef.current > 0) {
       historyPointerRef.current--;
@@ -417,6 +424,7 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
   const redo = useCallback(() => {
     if (!crdtRef.current || historyPointerRef.current >= strokeHistoryRef.current.length - 1) return null;
 
+    // 다음 로컬 엔트리 찾기
     let nextEntry = strokeHistoryRef.current[historyPointerRef.current + 1];
     while (nextEntry && !nextEntry.isLocal && historyPointerRef.current < strokeHistoryRef.current.length - 1) {
       historyPointerRef.current++;

--- a/client/src/hooks/useDrawing.ts
+++ b/client/src/hooks/useDrawing.ts
@@ -1,14 +1,5 @@
 import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
-import {
-  Point,
-  DrawingData,
-  LWWMap,
-  CRDTMessage,
-  MapState,
-  RegisterState,
-  CRDTUpdateMessage,
-  StrokeStyle,
-} from '@troublepainter/core';
+import { Point, DrawingData, LWWMap, CRDTMessage, MapState, RegisterState, StrokeStyle } from '@troublepainter/core';
 import { useParams } from 'react-router-dom';
 import type { DrawingMode, RGBA } from '@/types/canvas.types';
 import { DEFAULT_MAX_PIXELS, COLORS_INFO, DRAWING_MODE, LINEWIDTH_VARIABLE } from '@/constants/canvasConstants';
@@ -23,6 +14,7 @@ interface DrawingOptions {
 interface StrokeHistoryEntry {
   strokeIds: string[];
   isLocal: boolean;
+  drawingData: DrawingData;
 }
 
 // Fill 모드 유틸리티 함수들
@@ -118,10 +110,9 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
 
   // CRDT 및 히스토리 관리
   const crdtRef = useRef<LWWMap>();
-  const currentDrawingRef = useRef<DrawingData | null>(null);
   const strokeHistoryRef = useRef<StrokeHistoryEntry[]>([]);
-  const currentStrokeIdsRef = useRef<string[]>([]);
   const historyPointerRef = useRef<number>(-1);
+  const currentSessionStrokeIds = useRef<string[]>([]);
 
   const getCurrentStyle = useCallback((): StrokeStyle => {
     return {
@@ -136,6 +127,20 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
   }, [currentPlayerId]);
+
+  // 캔버스 전체 다시 그리기
+  const redrawCanvas = useCallback(() => {
+    if (!crdtRef.current) return;
+
+    const { canvas, ctx } = getCanvasContext(canvasRef);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    crdtRef.current.strokes
+      .filter((stroke) => stroke.stroke !== null)
+      .forEach(({ stroke }) => {
+        drawStroke(stroke);
+      });
+  }, []);
 
   // 단일 Stroke 그리는 함수
   const drawStroke = useCallback((drawingData: DrawingData) => {
@@ -227,23 +232,22 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
     (point: Point): CRDTMessage | null => {
       if (inkRemaining <= 0 || !crdtRef.current) return null;
 
-      currentStrokeIdsRef.current = [];
+      // 새로운 드로잉 세션 시작
+      currentSessionStrokeIds.current = [];
 
-      if (drawingMode === DRAWING_MODE.FILL) {
-        const fillData = floodFill(Math.floor(point.x), Math.floor(point.y));
-        if (!fillData) return null;
+      const drawingData =
+        drawingMode === DRAWING_MODE.FILL
+          ? floodFill(Math.floor(point.x), Math.floor(point.y))
+          : {
+              points: [point],
+              style: getCurrentStyle(),
+            };
 
-        currentDrawingRef.current = fillData;
-      } else {
-        currentDrawingRef.current = {
-          points: [point],
-          style: getCurrentStyle(),
-        };
-      }
+      if (!drawingData) return null;
 
-      const strokeId = crdtRef.current.addStroke(currentDrawingRef.current);
-      currentStrokeIdsRef.current.push(strokeId);
-      drawStroke(currentDrawingRef.current);
+      const strokeId = crdtRef.current.addStroke(drawingData);
+      currentSessionStrokeIds.current.push(strokeId);
+      drawStroke(drawingData);
 
       return {
         type: 'update',
@@ -253,28 +257,33 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
         },
       };
     },
-    [inkRemaining, currentColor, getCurrentStyle, drawingMode, floodFill, drawStroke],
+    [inkRemaining, getCurrentStyle, drawingMode, floodFill, drawStroke],
   );
 
   const draw = useCallback(
     (point: Point): CRDTMessage | null => {
-      if (!currentDrawingRef.current || !crdtRef.current || inkRemaining <= 0) return null;
-
-      // Fill 모드에서는 draw 동작 없음
+      if (!crdtRef.current || inkRemaining <= 0) return null;
       if (drawingMode === DRAWING_MODE.FILL) return null;
 
-      currentDrawingRef.current.points.push(point);
+      const lastStrokeId = currentSessionStrokeIds.current[currentSessionStrokeIds.current.length - 1];
+      const lastStroke = crdtRef.current.strokes.find((s) => s.id === lastStrokeId);
+      if (!lastStroke) return null;
+
+      const updatedDrawing = {
+        ...lastStroke.stroke,
+        points: [...lastStroke.stroke.points, point],
+      };
 
       // 잉크 소비량 계산
-      const lastPoint = currentDrawingRef.current.points[currentDrawingRef.current.points.length - 2];
+      const lastPoint = lastStroke.stroke.points[lastStroke.stroke.points.length - 1];
       const pixelsUsed = Math.ceil(
         Math.sqrt(Math.pow(point.x - lastPoint.x, 2) + Math.pow(point.y - lastPoint.y, 2)) * brushSize,
       );
       setInkRemaining((prev) => Math.max(0, prev - pixelsUsed));
 
-      const strokeId = crdtRef.current.addStroke(currentDrawingRef.current);
-      currentStrokeIdsRef.current.push(strokeId);
-      drawStroke(currentDrawingRef.current);
+      const strokeId = crdtRef.current.addStroke(updatedDrawing);
+      currentSessionStrokeIds.current.push(strokeId);
+      drawStroke(updatedDrawing);
 
       return {
         type: 'update',
@@ -288,21 +297,29 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
   );
 
   const stopDrawing = useCallback(() => {
-    if (currentStrokeIdsRef.current.length === 0) return;
+    if (!crdtRef.current || currentSessionStrokeIds.current.length === 0) return;
 
-    // 새로운 스트로크가 추가되면 redo 스택을 비움
+    // 새로운 stroke가 추가되면 redo 히스토리를 비움
     if (historyPointerRef.current < strokeHistoryRef.current.length - 1) {
       strokeHistoryRef.current = strokeHistoryRef.current.slice(0, historyPointerRef.current + 1);
     }
 
+    // 현재 세션의 마지막 stroke 가져오기
+    const lastStrokeId = currentSessionStrokeIds.current[currentSessionStrokeIds.current.length - 1];
+    const lastStroke = crdtRef.current.strokes.find((s) => s.id === lastStrokeId);
+
+    if (!lastStroke) return;
+
+    // 현재 세션의 모든 stroke를 하나의 히스토리 엔트리로 저장
     strokeHistoryRef.current.push({
-      strokeIds: [...currentStrokeIdsRef.current],
+      strokeIds: [...currentSessionStrokeIds.current],
       isLocal: true,
+      drawingData: lastStroke.stroke,
     });
     historyPointerRef.current = strokeHistoryRef.current.length - 1;
 
-    currentDrawingRef.current = null;
-    currentStrokeIdsRef.current = [];
+    // 현재 세션 초기화
+    currentSessionStrokeIds.current = [];
     updateHistoryState();
   }, [updateHistoryState]);
 
@@ -312,20 +329,16 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
       if (!crdtRef.current) return;
 
       if (crdtDrawingData.type === 'sync') {
-        // 전체 동기화
         const updatedKeys = crdtRef.current.merge(crdtDrawingData.state as MapState);
         if (updatedKeys.length > 0) {
-          // 모든 업데이트된 스트로크 그리기
-          updatedKeys.forEach((key) => {
-            const stroke = crdtRef.current!.state[key][2];
-            if (stroke) drawStroke(stroke);
-          });
+          // 전체 동기화 후 캔버스 다시 그리기
+          redrawCanvas();
 
-          // 히스토리 리셋
           strokeHistoryRef.current = [
             {
               strokeIds: updatedKeys,
               isLocal: false,
+              drawingData: crdtRef.current.strokes[crdtRef.current.strokes.length - 1].stroke,
             },
           ];
           historyPointerRef.current = 0;
@@ -342,29 +355,34 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
 
         if (crdtRef.current.mergeRegister(key, register)) {
           const stroke = register[2];
-          if (stroke !== null && !isLocalUpdate) {
-            // 원격 스트로크는 히스토리에 추가하고 바로 그리기
-            drawStroke(stroke);
-            if (historyPointerRef.current < strokeHistoryRef.current.length - 1) {
-              strokeHistoryRef.current = strokeHistoryRef.current.slice(0, historyPointerRef.current + 1);
+
+          if (!isLocalUpdate) {
+            // 원격 업데이트의 경우 캔버스 다시 그리기
+            redrawCanvas();
+
+            // stroke가 null이 아닌 경우 (삭제되지 않은 경우) 히스토리 추가
+            if (stroke) {
+              if (historyPointerRef.current < strokeHistoryRef.current.length - 1) {
+                strokeHistoryRef.current = strokeHistoryRef.current.slice(0, historyPointerRef.current + 1);
+              }
+              strokeHistoryRef.current.push({
+                strokeIds: [key],
+                isLocal: false,
+                drawingData: stroke,
+              });
+              historyPointerRef.current++;
+              updateHistoryState();
             }
-            strokeHistoryRef.current.push({
-              strokeIds: [key],
-              isLocal: false,
-            });
-            historyPointerRef.current++;
-            updateHistoryState();
           }
         }
       }
     },
-    [currentPlayerId, drawStroke, updateHistoryState],
+    [currentPlayerId, redrawCanvas, updateHistoryState],
   );
 
   const undo = useCallback(() => {
     if (!crdtRef.current || historyPointerRef.current < 0) return null;
 
-    // 현재 포인터부터 로컬 엔트리 찾기
     let currentEntry = strokeHistoryRef.current[historyPointerRef.current];
     while (currentEntry && !currentEntry.isLocal && historyPointerRef.current > 0) {
       historyPointerRef.current--;
@@ -373,6 +391,7 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
 
     if (!currentEntry?.isLocal) return null;
 
+    // 현재 엔트리의 모든 stroke 삭제
     const updates = currentEntry.strokeIds.map((strokeId) => {
       crdtRef.current!.deleteStroke(strokeId);
       return {
@@ -386,30 +405,14 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
 
     historyPointerRef.current--;
     updateHistoryState();
-
-    // 캔버스 지우고 현재 상태까지 다시 그리기
-    const { canvas, ctx } = getCanvasContext(canvasRef);
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    crdtRef.current.strokes
-      .filter(({ id }) => {
-        const strokePlayerId = id.split('-')[0];
-        if (strokePlayerId === currentPlayerId) {
-          return strokeHistoryRef.current
-            .slice(0, historyPointerRef.current + 1)
-            .some((entry) => entry.strokeIds.includes(id));
-        }
-        return true;
-      })
-      .forEach(({ stroke }) => drawStroke(stroke));
+    redrawCanvas();
 
     return updates;
-  }, [currentPlayerId, drawStroke, updateHistoryState]);
+  }, [redrawCanvas, updateHistoryState]);
 
   const redo = useCallback(() => {
     if (!crdtRef.current || historyPointerRef.current >= strokeHistoryRef.current.length - 1) return null;
 
-    // 다음 로컬 엔트리 찾기
     let nextEntry = strokeHistoryRef.current[historyPointerRef.current + 1];
     while (nextEntry && !nextEntry.isLocal && historyPointerRef.current < strokeHistoryRef.current.length - 1) {
       historyPointerRef.current++;
@@ -418,35 +421,27 @@ const useDrawing = (canvasRef: RefObject<HTMLCanvasElement>, options?: DrawingOp
 
     if (!nextEntry?.isLocal) return null;
 
-    const updates = nextEntry.strokeIds
-      .map((strokeId) => {
-        // 원본 스트로크 찾기
-        const originalStroke = crdtRef.current!.strokes.find((s) => s.id === strokeId)?.stroke;
-        if (!originalStroke) return null;
+    // 다음 엔트리의 drawingData로 새 stroke 생성
+    const strokeId = crdtRef.current.addStroke(nextEntry.drawingData);
+    if (!strokeId) return null;
 
-        // 새 스트로크 ID로 추가
-        const newStrokeId = crdtRef.current!.addStroke(originalStroke);
-        if (!newStrokeId) return null;
+    // strokeIds 업데이트
+    nextEntry.strokeIds = [strokeId];
 
-        drawStroke(originalStroke);
-
-        return {
-          type: 'update' as const,
-          state: {
-            key: newStrokeId,
-            register: crdtRef.current!.state[newStrokeId],
-          },
-        };
-      })
-      .filter((update): update is CRDTUpdateMessage => update !== null);
-
-    // 새로운 stroke ID로 히스토리 업데이트
-    nextEntry.strokeIds = updates.map((update) => update.state.key);
+    const update = {
+      type: 'update' as const,
+      state: {
+        key: strokeId,
+        register: crdtRef.current.state[strokeId],
+      },
+    };
 
     historyPointerRef.current++;
     updateHistoryState();
-    return updates;
-  }, [currentPlayerId, drawStroke, updateHistoryState]);
+    redrawCanvas();
+
+    return [update];
+  }, [redrawCanvas, updateHistoryState]);
 
   return {
     currentColor,


### PR DESCRIPTION
## 📂 작업 내용

closes #114 

- [x] CRDT 연동 중 undo/redo 오류 해결

## 💡 자세한 설명

> [!IMPORTANT]
>
> * 최적화된 코드 병합 전 CRDT 기반 undo/redo 기능 수정
> * 현재 구현된 코드는 undo/redo 기능이 우선적으로 제대로 동작하도록 수정된 상태입니다.
> * **필요하다면 최적화된 코드로 수정 가능합니다! (plz~)**
> * **리팩토링은 `useDrawing` 훅 분리 시 같이 진행하겠습니다!** (코멘트 남겨주시면 이후 PR에서 반영 예정)

1. StrokeHistoryEntry 구조 변경
```typescript
interface StrokeHistoryEntry {
  strokeIds: string[];      // 하나의 드로잉 세션(mouseup)에서 생성된 모든 stroke들의 ID
  isLocal: boolean;         // 로컬 사용자의 드로잉인지 여부
  drawingData: DrawingData; // 해당 세션의 최종 누적된 드로잉 데이터 
  // (mouseup(마우스를 떼는 시점)까지의 모든 stroke들을 하나의 히스토리 단위로 그룹화)
}
```
- drawingData는 해당 세션의 마지막 stroke 데이터를 저장 (모든 점들이 누적된 상태)
- redo 시 이 누적된 데이터를 사용하여 전체 선을 한 번에 복원
- `currentDrawingRef` 제거: 대신 CRDT의 stroke 데이터를 직접 참조하도록 변경

2. Undo/Redo 버튼 활성화 로직
- 로컬 사용자의 드로잉만을 기준으로 버튼 활성화 여부 결정
- 히스토리 포인터 계산 로직 수정
```typescript
const localItemsCount = strokeHistoryRef.current
  .slice(0, historyPointerRef.current + 1)
  .filter(entry => entry.isLocal)
  .length;

setCanUndo(localItemsCount > 0);
setCanRedo(localItemsCount < localHistory.length);
```

**작동 방식은 아래와 같습니다!**

1. 드로잉 프로세스
   - 마우스 드래그하는 동안 지속적으로 stroke 생성 (약 1/60초 간격)
   - 각 stroke는 즉시 CRDT에 저장되고 소켓으로 전송
   - mouseup 시점에 해당 세션의 모든 stroke들을 하나의 히스토리 엔트리로 저장

2. Undo/Redo 처리
   - Undo: 해당 세션의 모든 stroke들을 한 번에 삭제 (null값으로 삭제)
   - Redo: 저장된 누적 데이터로 전체 선을 한 번에 복원

## 📗 참고 자료 & 구현 결과 (선택)

https://github.com/user-attachments/assets/ef98187f-6efc-487d-8418-7f2e29844c34

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
