### PR TITLE
feat: Add timerSync handler to synchronize timer with server

### DIFF
--- a/client/src/pages/GameRoomPage.tsx
+++ b/client/src/pages/GameRoomPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { PlayerRole } from '@troublepainter/core';
 import { GameCanvas } from '@/components/canvas/GameCanvas';
 import RoleModal from '@/components/modal/RoleModal';
@@ -6,10 +5,9 @@ import { QuizTitle } from '@/components/ui/QuizTitle';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 
 const GameRoomPage = () => {
-  const [remainingTime] = useState(30);
-  const { players, currentPlayerId, room, roomSettings } = useGameSocketStore();
+  const { players, room, roomSettings, timer: drawingTimer } = useGameSocketStore();
 
-  if (!room || !players || !currentPlayerId || !roomSettings) return null;
+  if (!room || !players || !roomSettings || !room.currentWord) return null;
 
   return (
     <>
@@ -18,8 +16,8 @@ const GameRoomPage = () => {
       <QuizTitle
         currentRound={room.currentRound}
         totalRound={roomSettings.totalRounds}
-        title="뭘까요?뭘까요?뭘까요?뭘까요?"
-        remainingTime={remainingTime}
+        title={room.currentWord}
+        remainingTime={drawingTimer ?? roomSettings.drawTime - 5}
       />
       <GameCanvas role={PlayerRole.PAINTER} maxPixels={100000} />
     </>

--- a/client/src/pages/GameRoomPage.tsx
+++ b/client/src/pages/GameRoomPage.tsx
@@ -8,16 +8,14 @@ const GameRoomPage = () => {
   const { players, room, roomSettings, timer: drawingTimer } = useGameSocketStore();
 
   if (!room || !players || !roomSettings || !room.currentWord) return null;
-
   return (
     <>
       <RoleModal />
-      {/* 중앙 영역 - 게임 화면 */}
       <QuizTitle
         currentRound={room.currentRound}
         totalRound={roomSettings.totalRounds}
         title={room.currentWord}
-        remainingTime={drawingTimer ?? roomSettings.drawTime - 5}
+        remainingTime={drawingTimer ?? roomSettings.drawTime}
       />
       <GameCanvas role={PlayerRole.PAINTER} maxPixels={100000} />
     </>

--- a/client/src/stores/socket/gameSocket.store.ts
+++ b/client/src/stores/socket/gameSocket.store.ts
@@ -7,6 +7,7 @@ interface GameState {
   roomSettings: RoomSettings | null;
   players: Player[];
   currentPlayerId: string | null;
+  timer: number | null;
 }
 
 interface GameActions {
@@ -20,12 +21,16 @@ interface GameActions {
   // roomSetting 상태 업데이트
   updateRoomSettings: (settings: RoomSettings) => void;
 
-  //player 상태 업데이트
+  // player 상태 업데이트
   updatePlayers: (players: Player[]) => void;
   removePlayer: (playerId: string) => void;
   updatePlayerRole: (playerId: string, role: PlayerRole) => void;
 
   updateCurrentPlayerId: (currentPlayerId: string) => void;
+
+  // timer 상태 업데이트
+  updateTimer: (remaining: number) => void;
+  decreaseTimer: () => void;
 
   // 상태 초기화
   reset: () => void;
@@ -36,6 +41,7 @@ const initialState: GameState = {
   roomSettings: null,
   players: [],
   currentPlayerId: null,
+  timer: null,
 };
 
 /**
@@ -107,6 +113,16 @@ export const useGameSocketStore = create<GameState & { actions: GameActions }>()
         updatePlayerRole: (playerId, role) => {
           set((state) => ({
             players: state.players.map((player) => (player.playerId === playerId ? { ...player, role } : player)),
+          }));
+        },
+
+        updateTimer: (remaining) => {
+          set({ timer: remaining });
+        },
+
+        decreaseTimer: () => {
+          set((state) => ({
+            timer: state.timer && state.timer - 1,
           }));
         },
 

--- a/client/src/utils/checkTimerDifference.ts
+++ b/client/src/utils/checkTimerDifference.ts
@@ -1,3 +1,27 @@
+/**
+ * 두 타이머 값의 차이가 주어진 임계값 이상인지 확인합니다.
+ *
+ * @remarks
+ * - 타이머 값의 차이는 절대값으로 계산됩니다.
+ * - 임계값 이상이면 `true`, 그렇지 않으면 `false`를 반환합니다.
+ *
+ * @example
+ * ```typescript
+ * const isDifferenceExceeded = checkTimerDifference(10, 5, 3);
+ * console.log(isDifferenceExceeded); // true
+ *
+ * const isDifferenceExceeded = checkTimerDifference(10, 8, 3);
+ * console.log(isDifferenceExceeded); // false
+ * ```
+ *
+ * @param time1 - 첫 번째 타이머 값 (초 단위)
+ * @param time2 - 두 번째 타이머 값 (초 단위)
+ * @param threshold - 두 타이머 값 차이에 대한 임계값
+ *
+ * @returns 두 타이머 값의 차이가 임계값 이상인지 여부를 나타내는 `boolean`
+ *
+ * @category Utility
+ */
 export function checkTimerDifference(time1: number, time2: number, threshold: number) {
   const timeDifference = Math.abs(time1 - time2);
   return timeDifference >= threshold;

--- a/client/src/utils/checkTimerDifference.ts
+++ b/client/src/utils/checkTimerDifference.ts
@@ -1,0 +1,4 @@
+export function checkTimerDifference(time1: number, time2: number, threshold: number) {
+  const timeDifference = Math.abs(time1 - time2);
+  return timeDifference >= threshold;
+}

--- a/core/types/socket.types.ts
+++ b/core/types/socket.types.ts
@@ -1,5 +1,5 @@
-import { CRDTMessage } from '@/types/crdt.types';
-import { Player, PlayerRole, Room, RoomSettings } from '@/types/game.types';
+import { CRDTMessage, DrawingData } from "@/types/crdt.types";
+import { Player, PlayerRole, Room, RoomSettings } from "@/types/game.types";
 
 // 웹소켓 이벤트의 기본 응답 형식을 정의하는 제네릭 인터페이스
 // export interface SocketResponse<T = unknown> {
@@ -78,6 +78,14 @@ export interface UpdateSettingsRequest {
 
 export interface UpdateSettingsResponse {
   settings: RoomSettings;
+}
+
+export interface TimerSyncResponse {
+  remaining: number;
+}
+
+export interface DrawingTimeEnded {
+  drawingData: DrawingData;
 }
 
 export interface ReadyRequest {


### PR DESCRIPTION
## 📂 작업 내용

closes #120 

- [x] timeSync 트리거 될 때마다 전역 timer 값과 비교
- [x]  비교해서 time 차이가 1초 이상이면 전역 timer값 갱신
- [x]  time 차이 얼마인지 확인하는 util 구현
- [x]  전역 time 화면에 뿌리기

## 💡 자세한 설명

- timerSync 이벤트마다 client의 timer와 비교 후 1초 이상 차이나면 client의 timer를 업데이트합니다.
- timer 차이를 계산하는 checkTimerDifference util을 구현했습니다.
- 전역 timer를 화면에 뿌립니다. 

---

[개선 사항]
- 1초마다 setInterval 새로 생성되고, 없어짐 개선 필요
- 1초마다 timerSync 핸들러가 다시 생성되고 없어짐 개선 필요 
- 서버와 timer 동기화하는 로직 수정 


## 📗 참고 자료 & 구현 결과 (선택)

![timer2](https://github.com/user-attachments/assets/ea77df4c-b583-4bd9-b60d-5a6b27aaedb8)


## 📢 리뷰 요구 사항 (선택)


## 🚩 후속 작업 (선택)

- 1초마다 setInterval 새로 생성되고, 없어짐 개선 필요
- 1초마다 timerSync 핸들러가 다시 생성되고 없어짐 개선 필요 
- 서버와 sync 하는 로직 수정 

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
