### PR TITLE
feat: Implement answer checking system

### DIFF
--- a/server/src/exceptions/game.exception.ts
+++ b/server/src/exceptions/game.exception.ts
@@ -38,3 +38,9 @@ export class InsufficientPlayersException extends GameException {
     super(SocketErrorCode.INSUFFICIENT_PLAYERS, message);
   }
 }
+
+export class ForbiddenException extends GameException {
+  constructor(message: string = 'Forbidden') {
+    super(SocketErrorCode.FORBIDDEN, message);
+  }
+}


### PR DESCRIPTION
## 📂 작업 내용

closes #123

- [x] 정답 검증 시스템 구현
- [x] 소켓 에러를 위한 커스텀 ForbiddenException 추가

## 💡 자세한 설명

- 플레이어 답안 검증: 현재 단어와 플레이어가 제출한 답안을 비교하여 정답 여부 확인
- 점수 계산 및 업데이트: 정답일 경우, Painter는 2점, 정답을 맞힌 Guesser는 1점 추가
- 방 상태 및 라운드 번호 업데이트: 정답이 맞을 경우 방 상태를 업데이트하고 라운드 번호 증가
- Devil 역할 점수 부여: 타임아웃 발생 시 Devil 역할 플레이어에게 3점 부여
- 라운드 결과 반환: 승자를 포함한 라운드 결과와 업데이트된 플레이어 점수 반환

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
