### PR TITLE
refactor: Extract timer logic into useTimer hook 

### DIFF
--- a/client/src/components/modal/RoleModal.tsx
+++ b/client/src/components/modal/RoleModal.tsx
@@ -10,11 +10,11 @@ const RoleModal = () => {
 
   const myRole = players.find((player) => player.playerId === currentPlayerId)?.role || null;
 
-  if (!myRole) return null;
-
   useEffect(() => {
     if (myRole) openModal();
   }, [myRole, room?.currentRound]);
+
+  if (!myRole) return null;
 
   return (
     <Modal

--- a/client/src/hooks/socket/useGameSocket.ts
+++ b/client/src/hooks/socket/useGameSocket.ts
@@ -105,16 +105,6 @@ export const useGameSocket = () => {
   }, [roomId]);
 
   useEffect(() => {
-    if (clientTimer === 0 || clientTimer === null) return;
-
-    const intervalId = setInterval(() => {
-      gameActions.decreaseTimer();
-    }, 1000);
-
-    return () => clearInterval(intervalId);
-  }, [clientTimer, gameActions]);
-
-  useEffect(() => {
     const socket = sockets.game;
     if (!socket || !roomId) return;
 
@@ -150,21 +140,23 @@ export const useGameSocket = () => {
       },
 
       drawingGroupRoundStarted: (response: RoundStartResponse) => {
-        const { roundNumber, roles, word } = response;
+        const { roundNumber, roles, word, drawTime } = response;
         const { painters, devil, guessers } = roles;
         gameActions.updateCurrentRound(roundNumber);
         painters?.forEach((playerId) => gameActions.updatePlayerRole(playerId, PlayerRole.PAINTER));
         guessers?.forEach((playerId) => gameActions.updatePlayerRole(playerId, PlayerRole.GUESSER));
         if (devil) gameActions.updatePlayerRole(devil, PlayerRole.DEVIL);
         if (word) gameActions.updateCurrentWord(word);
+        gameActions.updateTimer(drawTime);
         navigate(`/game/${roomId}`);
       },
 
       guesserRoundStarted: (response: RoundStartResponse) => {
-        const { roundNumber, roles } = response;
+        const { roundNumber, roles, drawTime } = response;
         const { guessers } = roles;
         gameActions.updateCurrentRound(roundNumber);
         guessers?.forEach((playerId) => gameActions.updatePlayerRole(playerId, PlayerRole.GUESSER));
+        gameActions.updateTimer(drawTime);
         navigate(`/game/${roomId}`);
       },
 
@@ -174,10 +166,6 @@ export const useGameSocket = () => {
         if (clientTimer === null || checkTimerDifference(serverTimer, clientTimer, 1))
           gameActions.updateTimer(serverTimer);
       },
-
-      /*       drawingTimeEnded: () => {
-        console.log('drawingTimeEnded Trigger');
-      }, */
     };
 
     // 이벤트 리스너 등록

--- a/client/src/hooks/useTimer.ts
+++ b/client/src/hooks/useTimer.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+
+interface UseTimerProps {
+  timer: number | null;
+  onTick: () => void;
+}
+
+export const useTimer = ({ timer, onTick }: UseTimerProps) => {
+  const intervalIdRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (timer !== null && timer > 0 && !intervalIdRef.current) {
+      intervalIdRef.current = setInterval(onTick, 1000);
+    } else if ((timer === null || timer <= 0) && intervalIdRef.current) {
+      clearInterval(intervalIdRef.current);
+      intervalIdRef.current = null;
+    }
+
+    return () => {
+      if (intervalIdRef.current) {
+        clearInterval(intervalIdRef.current);
+        intervalIdRef.current = null;
+      }
+    };
+  }, [timer !== null && timer > 0]);
+};

--- a/client/src/hooks/useTimer.ts
+++ b/client/src/hooks/useTimer.ts
@@ -1,5 +1,36 @@
 import { useEffect, useRef } from 'react';
 
+/**
+ * `setInterval`을 사용하여 타이머를 관리하는 커스텀 React 훅입니다.
+ * 유효한 `timer` 값이 전달되면 타이머가 시작되며, `timer`가 `null`이 되거나 0 이하가 되면 타이머가 중지됩니다.
+ *
+ * @param {UseTimerProps} props - 타이머 설정을 위한 속성입니다.
+ * @param {number | null} props.timer - 현재 타이머 값입니다. `null`이거나 0 이하일 경우 타이머가 중지됩니다.
+ * @param {() => void} props.onTick - 매 1초 간격으로 호출되는 콜백 함수입니다.
+ *
+ * @example
+ * ```tsx
+ * import { useState } from "react";
+ * import { useTimer } from "./useTimer";
+ *
+ * const TimerComponent = () => {
+ *   const [timer, setTimer] = useState(10); // 초기 타이머 값 설정
+ *
+ *   // useTimer 훅 사용
+ *   useTimer({
+ *     timer,
+ *     onTick: () => setTimer(prev => prev - 1), // 매 초 타이머 값을 감소
+ *   });
+ *
+ *   return (
+ *     <div>
+ *       <h1>남은 시간: {timer}</h1>
+ *     </div>
+ *   );
+ * };
+ * ```
+ */
+
 interface UseTimerProps {
   timer: number | null;
   onTick: () => void;

--- a/client/src/hooks/useTimer.ts
+++ b/client/src/hooks/useTimer.ts
@@ -40,18 +40,28 @@ export const useTimer = ({ timer, onTick }: UseTimerProps) => {
   const intervalIdRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
-    if (timer !== null && timer > 0 && !intervalIdRef.current) {
-      intervalIdRef.current = setInterval(onTick, 1000);
-    } else if ((timer === null || timer <= 0) && intervalIdRef.current) {
-      clearInterval(intervalIdRef.current);
-      intervalIdRef.current = null;
-    }
+    const isTimerActive = timer !== null && timer > 0;
+    const hasInterval = intervalIdRef.current !== null;
 
-    return () => {
-      if (intervalIdRef.current) {
-        clearInterval(intervalIdRef.current);
+    const startTimer = () => {
+      if (!hasInterval) {
+        intervalIdRef.current = setInterval(onTick, 1000);
+      }
+    };
+
+    const stopTimer = () => {
+      if (hasInterval) {
+        clearInterval(intervalIdRef.current!);
         intervalIdRef.current = null;
       }
     };
+
+    if (isTimerActive) {
+      startTimer();
+    } else {
+      stopTimer();
+    }
+
+    return () => stopTimer();
   }, [timer !== null && timer > 0]);
 };

--- a/client/src/pages/GameRoomPage.tsx
+++ b/client/src/pages/GameRoomPage.tsx
@@ -2,10 +2,13 @@ import { PlayerRole } from '@troublepainter/core';
 import { GameCanvas } from '@/components/canvas/GameCanvas';
 import RoleModal from '@/components/modal/RoleModal';
 import { QuizTitle } from '@/components/ui/QuizTitle';
+import { useTimer } from '@/hooks/useTimer';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 
 const GameRoomPage = () => {
-  const { players, room, roomSettings, timer: drawingTimer } = useGameSocketStore();
+  const { players, room, roomSettings, timer: drawingTimer, actions } = useGameSocketStore();
+
+  useTimer({ timer: drawingTimer, onTick: actions.decreaseTimer });
 
   if (!room || !players || !roomSettings || !room.currentWord) return null;
   return (


### PR DESCRIPTION
## 📂 작업 내용

closes #131 

- [x] 1초마다 setInterval 새로 생성되고 없어지는 것 ref로 개선
- [x] 1초마다 timerSync 핸들러가 다시 생성되고 없어지는 것 개선

## 💡 자세한 설명

### 1. timer 로직 분리
- 기존에 useGmaeSocket에 있던 `timer 로직을 분리` 
- GameRoomPage에서 useTimer hook을 호출하도록 변경 

### 2. setInterval 한 번만 생성 
- 기존에 time 마다 setInterval을 생성하는 것에서 `ref를 사용해 setInterval을 한 번만 생성`하도록 변경 
- `getState().timer`를 사용함으로써 useEffect에서 timer 의존성 삭제 

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
