### PR TITLE
feat: Implement global state initialization for round end and game end 

### DIFF
--- a/client/src/components/setting/Setting.tsx
+++ b/client/src/components/setting/Setting.tsx
@@ -21,12 +21,12 @@ export const ROOM_SETTINGS: RoomSettingItem[] = [
 ];
 
 const Setting = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
-  const { roomSettings, isHost } = useGameSocketStore();
+  const { roomSettings, isHost, actions } = useGameSocketStore();
 
-  const [selectedValues, setSelectedValues] = useState<Partial<RoomSettings>>({
-    totalRounds: undefined,
-    maxPlayers: undefined,
-    drawTime: undefined,
+  const [selectedValues, setSelectedValues] = useState<RoomSettings>({
+    totalRounds: 5,
+    maxPlayers: 5,
+    drawTime: 30,
   });
 
   useEffect(() => {
@@ -39,6 +39,7 @@ const Setting = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
     void gameSocketHandlers.updateSettings({
       settings: { ...selectedValues, drawTime: selectedValues.drawTime + 5 },
     });
+    actions.updateRoomSettings(selectedValues);
   }, [selectedValues]);
 
   const handleChange = (key: SettingKey) => (value: string) => {

--- a/client/src/hooks/socket/useGameSocket.ts
+++ b/client/src/hooks/socket/useGameSocket.ts
@@ -143,6 +143,7 @@ export const useGameSocket = () => {
       },
 
       drawingGroupRoundStarted: (response: RoundStartResponse) => {
+        gameActions.resetRound();
         const { roundNumber, roles, word, assignedRole, drawTime } = response;
         const { painters, devils, guessers } = roles;
         gameActions.updateCurrentRound(roundNumber);
@@ -157,6 +158,7 @@ export const useGameSocket = () => {
       },
 
       guesserRoundStarted: (response: RoundStartResponse) => {
+        gameActions.resetRound();
         const { roundNumber, roles, assignedRole, drawTime } = response;
         const { guessers } = roles;
         gameActions.updateCurrentRound(roundNumber);
@@ -188,6 +190,10 @@ export const useGameSocket = () => {
         gameActions.updateRoundWinner(winner);
         gameActions.updateTimer(TimerType.ENDING, 10);
         gameActions.updatePlayers(players);
+      },
+
+      gameEnded: () => {
+        gameActions.resetGame();
       },
     };
 

--- a/client/src/hooks/socket/useGameSocket.ts
+++ b/client/src/hooks/socket/useGameSocket.ts
@@ -194,6 +194,7 @@ export const useGameSocket = () => {
 
       gameEnded: () => {
         gameActions.resetGame();
+        navigate(`/lobby/${roomId}`, { replace: true });
       },
     };
 

--- a/client/src/stores/socket/gameSocket.store.ts
+++ b/client/src/stores/socket/gameSocket.store.ts
@@ -1,4 +1,4 @@
-import { Player, PlayerRole, Room, RoomSettings, RoomStatus, TimerType } from '@troublepainter/core';
+import { Player, PlayerRole, PlayerStatus, Room, RoomSettings, RoomStatus, TimerType } from '@troublepainter/core';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
@@ -43,6 +43,8 @@ interface GameActions {
   updateRoundWinner: (player: Player) => void;
 
   // 상태 초기화
+  resetRound: () => void;
+  resetGame: () => void;
   reset: () => void;
 }
 
@@ -56,6 +58,14 @@ const initialState: GameState = {
   roundWinner: null,
   roundAssignedRole: null,
 };
+
+const resetRoundState = (state: GameState) => ({
+  room: state.room ? { ...state.room, currentWord: '' } : null,
+  roundWinner: null,
+  roundAssignedRole: null,
+  timers: { DRAWING: null, ENDING: null, GUESSING: null },
+  players: state.players.map((player) => ({ ...player, role: undefined })),
+});
 
 /**
  * 게임 상태를 관리하는 Store입니다.
@@ -166,6 +176,24 @@ export const useGameSocketStore = create<GameState & { actions: GameActions }>()
         // 상태 초기화
         reset: () => {
           set(initialState);
+        },
+
+        // 라운드 상태 초기화
+        resetRound: () => {
+          set((state) => ({
+            ...state,
+            ...resetRoundState(state),
+          }));
+        },
+
+        // 게임 상태 초기화
+        resetGame: () => {
+          set((state) => ({
+            ...state,
+            ...resetRoundState(state),
+            room: state.room && { ...state.room, status: RoomStatus.WAITING, currentRound: 0 },
+            players: state.players.map((player) => ({ ...player, score: 0, status: PlayerStatus.NOT_PLAYING })),
+          }));
         },
       },
     }),


### PR DESCRIPTION
## 📂 작업 내용

closes #148 

- [x] 라운드 종료일 때 전역 상태 초기화
- [x] 게임 종료일 때 전역 상태 초기화하고 lobby로 리다이렉트 

## 💡 자세한 설명

### 1. 라운드 종료 후 상태 초기화
- 라운드 시작 전 초기화

-  room.currentWord = ""
- roundWinner = null
- currentAssignedRole = null
- player.role = undefined
- timers = { DRAWING: null, ENDING: null, GUESSING: null };

### 2. 게임 종료 후 상태 초기화
- 이후 게임 결과 화면이 구현되면, 사용자가 대기방으로 가기 버튼을 눌렀을 때 게임 상태를 초기화하려고함 

 - room.currentWord= ""
 - roundWinner= null
 - roundAssignedRole:null
 - player.role=undefined
 - timers= { DRAWING: null, ENDING: null, GUESSING: null }
 -  player.score=0
 - room.status = WAITING
 - room.currentRound= 0
 - player.status=NOT_PLAYING

### 3. 중복되는 초기화 내용
- 라운드 끝났을 때 초기화할 것, 게임 끝났을 때 초기화 할 것 중 중복되는 것은 resetRoundState 함수로 빼고, resetRound와 resetGame에서 가져다 사용하는 형태로 구현 . 


## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
