### PR TITLE
refactor: Improve room and player validation

### DIFF
--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -3,7 +3,7 @@ import { Server, Socket } from 'socket.io';
 import { ChatService } from './chat.service';
 import { UseFilters } from '@nestjs/common';
 import { WsExceptionFilter } from 'src/filters/ws-exception.filter';
-import { BadRequestException } from 'src/exceptions/game.exception';
+import { BadRequestException, PlayerNotFoundException, RoomNotFoundException } from 'src/exceptions/game.exception';
 
 @WebSocketGateway({
   cors: '*',
@@ -21,6 +21,11 @@ export class ChatGateway {
     const playerId = client.handshake.auth.playerId;
 
     if (!roomId || !playerId) throw new BadRequestException('Room ID and Player ID are required');
+
+    const roomExists = this.chatService.existsRoom(roomId);
+    if (!roomExists) throw new RoomNotFoundException('Room not found');
+    const playerExists = this.chatService.existsPlayer(roomId, playerId);
+    if (!playerExists) throw new PlayerNotFoundException('Player not found in room');
 
     client.data.roomId = roomId;
     client.data.playerId = playerId;

--- a/server/src/chat/chat.repository.ts
+++ b/server/src/chat/chat.repository.ts
@@ -17,4 +17,14 @@ export class ChatRepository {
       score: parseInt(player.score, 10) || 0,
     } as Player;
   }
+
+  async existsRoom(roomId: string) {
+    const exists = await this.redisService.exists(`room:${roomId}`);
+    return exists === 1;
+  }
+
+  async existsPlayer(roomId: string, playerId: string) {
+    const exists = await this.redisService.exists(`room:${roomId}:player:${playerId}`);
+    return exists === 1;
+  }
 }

--- a/server/src/chat/chat.service.ts
+++ b/server/src/chat/chat.service.ts
@@ -21,4 +21,12 @@ export class ChatService {
       createdAt: new Date(),
     };
   }
+
+  async existsRoom(roomId: string) {
+    return await this.chatRepository.existsRoom(roomId);
+  }
+
+  async existsPlayer(roomId: string, playerId: string) {
+    return await this.chatRepository.existsPlayer(roomId, playerId);
+  }
 }

--- a/server/src/drawing/drawing.module.ts
+++ b/server/src/drawing/drawing.module.ts
@@ -1,7 +1,11 @@
 import { Module } from '@nestjs/common';
 import { DrawingGateway } from './drawing.gateway';
+import { RedisModule } from 'src/redis/redis.module';
+import { DrawingService } from './drawing.service';
+import { DrawingRepository } from './drawing.repository';
 
 @Module({
-  providers: [DrawingGateway],
+  imports: [RedisModule],
+  providers: [DrawingGateway, DrawingService, DrawingRepository],
 })
 export class DrawingModule {}

--- a/server/src/drawing/drawing.repository.ts
+++ b/server/src/drawing/drawing.repository.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { RedisService } from 'src/redis/redis.service';
+
+@Injectable()
+export class DrawingRepository {
+  constructor(private readonly redisService: RedisService) {}
+
+  async existsRoom(roomId: string) {
+    const exists = await this.redisService.exists(`room:${roomId}`);
+    return exists === 1;
+  }
+
+  async existsPlayer(roomId: string, playerId: string) {
+    const exists = await this.redisService.exists(`room:${roomId}:player:${playerId}`);
+    return exists === 1;
+  }
+}

--- a/server/src/drawing/drawing.service.ts
+++ b/server/src/drawing/drawing.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { DrawingRepository } from './drawing.repository';
+
+@Injectable()
+export class DrawingService {
+  constructor(private readonly drawingRepository: DrawingRepository) {}
+
+  async existsRoom(roomId: string) {
+    return await this.drawingRepository.existsRoom(roomId);
+  }
+
+  async existsPlayer(roomId: string, playerId: string) {
+    return await this.drawingRepository.existsPlayer(roomId, playerId);
+  }
+}

--- a/server/src/exceptions/game.exception.ts
+++ b/server/src/exceptions/game.exception.ts
@@ -44,3 +44,8 @@ export class ForbiddenException extends GameException {
     super(SocketErrorCode.FORBIDDEN, message);
   }
 }
+export class GameAlreadyStartedException extends GameException {
+  constructor(message: string = 'Game already started') {
+    super(SocketErrorCode.GAME_ALREADY_STARTED, message);
+  }
+}

--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -11,8 +11,8 @@ import { GameService } from './game.service';
 import { UseFilters } from '@nestjs/common';
 import { WsExceptionFilter } from 'src/filters/ws-exception.filter';
 import { Player, Room, RoomSettings } from 'src/common/types/game.types';
-import { BadRequestException } from 'src/exceptions/game.exception';
-import { PlayerRole } from 'src/common/enums/game.status.enum';
+import { BadRequestException, RoomNotFoundException } from 'src/exceptions/game.exception';
+import { PlayerRole, RoomStatus } from 'src/common/enums/game.status.enum';
 import { TimerService } from 'src/common/services/timer.service';
 import { TimerType } from 'src/common/enums/game.timer.enum';
 
@@ -36,6 +36,12 @@ export class GameGateway implements OnGatewayDisconnect {
 
   @SubscribeMessage('joinRoom')
   async handleJoinRoom(@ConnectedSocket() client: Socket, @MessageBody() data: { roomId: string }) {
+    const roomStatus = await this.gameService.getRoomStatus(data.roomId);
+    if (!roomStatus) throw new RoomNotFoundException('Room not found');
+    if (roomStatus === RoomStatus.GUESSING || roomStatus === RoomStatus.DRAWING) {
+      throw new BadRequestException('Cannot join room while game is in progress');
+    }
+
     const { room, roomSettings, player, players } = await this.gameService.joinRoom(data.roomId);
 
     client.data.playerId = player.playerId;

--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -11,7 +11,7 @@ import { GameService } from './game.service';
 import { UseFilters } from '@nestjs/common';
 import { WsExceptionFilter } from 'src/filters/ws-exception.filter';
 import { Player, Room, RoomSettings } from 'src/common/types/game.types';
-import { BadRequestException, RoomNotFoundException } from 'src/exceptions/game.exception';
+import { BadRequestException, GameAlreadyStartedException, RoomNotFoundException } from 'src/exceptions/game.exception';
 import { PlayerRole, RoomStatus } from 'src/common/enums/game.status.enum';
 import { TimerService } from 'src/common/services/timer.service';
 import { TimerType } from 'src/common/enums/game.timer.enum';
@@ -39,7 +39,7 @@ export class GameGateway implements OnGatewayDisconnect {
     const roomStatus = await this.gameService.getRoomStatus(data.roomId);
     if (!roomStatus) throw new RoomNotFoundException('Room not found');
     if (roomStatus === RoomStatus.GUESSING || roomStatus === RoomStatus.DRAWING) {
-      throw new BadRequestException('Cannot join room while game is in progress');
+      throw new GameAlreadyStartedException('Cannot join room while game is in progress');
     }
 
     const { room, roomSettings, player, players } = await this.gameService.joinRoom(data.roomId);

--- a/server/src/game/game.repository.ts
+++ b/server/src/game/game.repository.ts
@@ -39,6 +39,10 @@ export class GameRepository {
     await multi.exec();
   }
 
+  async getRoomStatus(roomId: string) {
+    return this.redisService.hget(`room:${roomId}`, 'status') as Promise<RoomStatus>;
+  }
+
   async getRoomSettings(roomId: string) {
     const settings = await this.redisService.hgetall(`room:${roomId}:settings`);
 

--- a/server/src/game/game.service.ts
+++ b/server/src/game/game.service.ts
@@ -78,6 +78,10 @@ export class GameService {
     return { room, roomSettings, player, players: updatedPlayers };
   }
 
+  getRoomStatus(roomId: string) {
+    return this.gameRepository.getRoomStatus(roomId);
+  }
+
   async reconnect(roomId: string, playerId: string) {
     const [room, roomSettings, players] = await Promise.all([
       this.gameRepository.getRoom(roomId),

--- a/server/src/game/game.service.ts
+++ b/server/src/game/game.service.ts
@@ -266,14 +266,14 @@ export class GameService {
     await Promise.all(
       updatedPlayers.map((p) => this.gameRepository.updatePlayer(roomId, p.playerId, { score: p.score })),
     );
-
-    const winner = currentPlayer;
+    const painters = updatedPlayers.filter((p) => p.role === PlayerRole.PAINTER);
+    const winner = updatedPlayers.find((p) => p.playerId === playerId);
 
     return {
       isCorrect,
       roundNumber: room.currentRound,
       word: room.currentWord,
-      winner,
+      winners: [winner, ...painters],
       players: updatedPlayers,
     };
   }
@@ -324,7 +324,7 @@ export class GameService {
     return {
       roundNumber: room.currentRound,
       word: room.currentWord,
-      winner,
+      winners: [winner],
       players: updatedPlayers,
     };
   }

--- a/server/src/redis/redis.service.ts
+++ b/server/src/redis/redis.service.ts
@@ -48,6 +48,10 @@ export class RedisService {
     await this.redis.lrem(key, count, value);
   }
 
+  async exists(key: string): Promise<number> {
+    return await this.redis.exists(key);
+  }
+
   multi() {
     return this.redis.multi();
   }


### PR DESCRIPTION
## 📂 작업 내용

closes #156

- [x] 없는 방이나 플레이어 접속 시 에러 반환
- [x] 우승자 데이터를 배열 구조로 리팩터링
- [x] 게임이 진행 중인 방에 새로운 플레이어가 조인하지 못하도록 제한  

## 💡 자세한 설명

검증 로직
- 방 존재 여부 체크 로직 추가 
- 활성화된 방의 플레이어 검증 로직 추가

방 접근 제어 
- 게임 진행중인 방 입장 제한
- joinRoom 게이트웨이에 status 체크 추가
- 게임 중 입장 시도 시, 에러 메시지 반환 

반환 타입
- 우승자 데이터 구조를 배열로 변경
- 정답자와 함께 화가도 우승자 배열에 포함
- 다수 우승자 처리를 위한 반환 타입 수정

주의: 응답의 winners 필드가 단일 우승자에서 배열로 변경됨

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
