### PR TITLE
fix: Update navigation logic and fix URL handling

### DIFF
--- a/client/src/layouts/BrowserNavigationGuard.tsx
+++ b/client/src/layouts/BrowserNavigationGuard.tsx
@@ -14,8 +14,8 @@ const BrowserNavigationGuard = () => {
       e.preventDefault();
       e.returnValue = ''; // 레거시 브라우저 지원
 
-      // 새로고침 시 메인으로 이동하도록 로컬스토리지에 플래그 저장
-      localStorage.setItem('shouldRedirect', 'true');
+      // 새로고침 시 메인으로 이동하도록 세션스토리지에 플래그 저장
+      sessionStorage.setItem('shouldRedirect', 'true');
 
       // 사용자 정의 메시지 반환 (일부 브라우저에서는 무시될 수 있음)
       return '게임을 종료하시겠습니까? 현재 진행 상태가 저장되지 않을 수 있습니다.';
@@ -38,10 +38,10 @@ const BrowserNavigationGuard = () => {
     window.addEventListener('popstate', handlePopState);
 
     // 새로고침 후 리다이렉트 체크
-    const shouldRedirect = localStorage.getItem('shouldRedirect');
+    const shouldRedirect = sessionStorage.getItem('shouldRedirect');
     if (shouldRedirect === 'true' && location.pathname !== '/') {
       navigate('/', { replace: true });
-      localStorage.removeItem('shouldRedirect');
+      sessionStorage.removeItem('shouldRedirect');
     }
 
     return () => {

--- a/client/src/layouts/RootLayout.tsx
+++ b/client/src/layouts/RootLayout.tsx
@@ -9,7 +9,6 @@ const RootLayout = () => {
   // 레이아웃 마운트 시 localStorage 초기화
   useEffect(() => {
     playerIdStorageUtils.removeAllPlayerIds();
-    localStorage.removeItem('shouldRedirect');
   }, []);
 
   return (

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Logo } from '@/components/ui/Logo';
 import { PixelTransitionContainer } from '@/components/ui/PixelTransitionContainer';
@@ -8,6 +9,11 @@ import { cn } from '@/utils/cn';
 const MainPage = () => {
   const { createRoom, isLoading } = useCreateRoom();
   const { isExiting, transitionTo } = usePageTransition();
+
+  useEffect(() => {
+    // 현재 URL을 루트로 변경
+    window.history.replaceState(null, '', '/');
+  }, []);
 
   const handleCreateRoom = async () => {
     // transitionTo(`/lobby/${roomId}`);


### PR DESCRIPTION
## 📂 작업 내용

closes #160 

- [x] 세션스토리지로 리다이렉트 로직 변경
- [x] 메인 페이지로 이동 시 URL을 루트로 변경하는 기능 추가

## 💡 자세한 설명

- 이전에는 `localStorage`를 사용 및 리다이렉트 플래그를 저장, 이는 페이지 새로고침 후에도 플래그가 남아 있어 불필요한 리다이렉트를 발생시킬 수 있었음
- 페이지 새로고침 시 플래그가 자동으로 제거되도록 `sessionStorage`를 사용하도록 변경
- 메인 페이지로 이동할 때 현재 URL을 루트(`"/"`)로 변경 기능 추가, 사용자가 메인 페이지에 도착했을 때 URL이 일관되게 표시

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
