### PR TITLE
chore: Set up Prettier for consistent formatting in core package

### DIFF
--- a/core/.prettierrc
+++ b/core/.prettierrc
@@ -1,0 +1,14 @@
+{
+    "printWidth": 120,
+    "tabWidth": 2,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": true,
+    "quoteProps": "as-needed",
+    "trailingComma": "all",
+    "bracketSpacing": true,
+    "arrowParens": "always",
+    "proseWrap": "preserve",
+    "endOfLine": "auto",
+    "embeddedLanguageFormatting": "auto"
+}

--- a/core/crdt/LWWMap.ts
+++ b/core/crdt/LWWMap.ts
@@ -37,11 +37,7 @@ export class LWWMap {
   addStroke(stroke: DrawingData): string {
     const timestamp = Date.now();
     const id = `${this.id}-${timestamp}-${Math.random().toString(36).substring(2, 9)}`;
-    const register = new LWWRegister<DrawingData | null>(this.id, [
-      this.id,
-      timestamp,
-      stroke,
-    ]);
+    const register = new LWWRegister<DrawingData | null>(this.id, [this.id, timestamp, stroke]);
     this.#data.set(id, register);
     return id;
   }
@@ -79,10 +75,7 @@ export class LWWMap {
   }
 
   // 단일 레지스터 업데이트
-  mergeRegister(
-    key: string,
-    remoteRegisterState: RegisterState<DrawingData | null>
-  ): boolean {
+  mergeRegister(key: string, remoteRegisterState: RegisterState<DrawingData | null>): boolean {
     const localRegister = this.#data.get(key);
 
     if (localRegister) {

--- a/core/crdt/LWWRegister.ts
+++ b/core/crdt/LWWRegister.ts
@@ -26,10 +26,7 @@ export class LWWRegister<T> {
     const [remotePeer, remoteTimestamp] = remoteState;
     const [localPeer, localTimestamp] = this.#state;
 
-    if (
-      remoteTimestamp > localTimestamp ||
-      (remoteTimestamp === localTimestamp && remotePeer > localPeer)
-    ) {
+    if (remoteTimestamp > localTimestamp || (remoteTimestamp === localTimestamp && remotePeer > localPeer)) {
       this.#state = remoteState;
       return true;
     }

--- a/core/crdt/test/LWWMap.test.ts
+++ b/core/crdt/test/LWWMap.test.ts
@@ -2,10 +2,7 @@ import { DrawingData, MapState, RegisterState } from '@/types/crdt.types';
 import { LWWMap } from '@/crdt/LWWMap';
 
 describe('LWWMap', () => {
-  const createTestStroke = (
-    color: string = '#000000',
-    width: number = 2
-  ): DrawingData => ({
+  const createTestStroke = (color: string = '#000000', width: number = 2): DrawingData => ({
     points: [
       { x: 0, y: 0 },
       { x: 2, y: 2 },
@@ -153,11 +150,7 @@ describe('LWWMap', () => {
       const modifyTime = deleteTime + 1000;
       vi.setSystemTime(modifyTime);
       const modifiedStroke = createTestStroke('#0000ff');
-      const modifiedState: RegisterState<DrawingData | null> = [
-        'peer2',
-        modifyTime,
-        modifiedStroke,
-      ];
+      const modifiedState: RegisterState<DrawingData | null> = ['peer2', modifyTime, modifiedStroke];
       map2.mergeRegister(id, modifiedState);
 
       // 양방향 동기화

--- a/core/crdt/test/LWWRegister.test.ts
+++ b/core/crdt/test/LWWRegister.test.ts
@@ -2,10 +2,7 @@ import { LWWRegister } from '@/crdt/LWWRegister';
 import { DrawingData, RegisterState } from '@/types/crdt.types';
 
 describe('LWWRegister', () => {
-  const createTestStroke = (
-    color: string = '#000000',
-    width: number = 2
-  ): DrawingData => ({
+  const createTestStroke = (color: string = '#000000', width: number = 2): DrawingData => ({
     points: [
       { x: 0, y: 0 },
       { x: 2, y: 2 },
@@ -21,11 +18,7 @@ describe('LWWRegister', () => {
 
   beforeEach(() => {
     const initialStroke = createTestStroke();
-    const initialState: RegisterState<DrawingData> = [
-      'peer1',
-      Date.now(),
-      initialStroke,
-    ];
+    const initialState: RegisterState<DrawingData> = ['peer1', Date.now(), initialStroke];
     register = new LWWRegister('peer1', initialState);
   });
 
@@ -80,11 +73,7 @@ describe('LWWRegister', () => {
       const newTime = oldTime + 1000;
       vi.setSystemTime(newTime);
       const remoteStroke = createTestStroke('#00ff00');
-      const remoteState: RegisterState<DrawingData> = [
-        'peer2',
-        newTime,
-        remoteStroke,
-      ];
+      const remoteState: RegisterState<DrawingData> = ['peer2', newTime, remoteStroke];
 
       const updated = register.merge(remoteState);
 
@@ -110,11 +99,7 @@ describe('LWWRegister', () => {
       // 더 오래된 타임스탬프로 원격 상태 생성
       const oldTime = newTime - 1000;
       const remoteStroke = createTestStroke('#00ff00');
-      const remoteState: RegisterState<DrawingData> = [
-        'peer2',
-        oldTime,
-        remoteStroke,
-      ];
+      const remoteState: RegisterState<DrawingData> = ['peer2', oldTime, remoteStroke];
 
       const updated = register.merge(remoteState);
 
@@ -131,20 +116,12 @@ describe('LWWRegister', () => {
       // 동일한 타임스탬프에서의 충돌 해결 테스트
       const timestamp = Date.now();
       const localStroke = createTestStroke('#ff0000');
-      const localState: RegisterState<DrawingData> = [
-        'peer1',
-        timestamp,
-        localStroke,
-      ];
+      const localState: RegisterState<DrawingData> = ['peer1', timestamp, localStroke];
       const localRegister = new LWWRegister('peer1', localState);
 
       // 동일한 타임스탬프지만 더 높은 peer ID를 가진 원격 상태 생성
       const remoteStroke = createTestStroke('#00ff00');
-      const remoteState: RegisterState<DrawingData> = [
-        'peer2',
-        timestamp,
-        remoteStroke,
-      ];
+      const remoteState: RegisterState<DrawingData> = ['peer2', timestamp, remoteStroke];
 
       const updated = localRegister.merge(remoteState);
 
@@ -156,11 +133,7 @@ describe('LWWRegister', () => {
     it('should handle null values in merge', () => {
       const timestamp = Date.now();
       // null 값을 포함한 원격 상태 생성
-      const remoteState: RegisterState<DrawingData | null> = [
-        'peer2',
-        timestamp + 1000,
-        null,
-      ];
+      const remoteState: RegisterState<DrawingData | null> = ['peer2', timestamp + 1000, null];
 
       const updated = register.merge(remoteState);
 

--- a/core/package.json
+++ b/core/package.json
@@ -16,7 +16,9 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest",
-    "test:watch": "vitest watch"
+    "test:watch": "vitest watch",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/core/types/game.types.ts
+++ b/core/types/game.types.ts
@@ -22,22 +22,22 @@ export interface RoomSettings {
 }
 
 export enum PlayerStatus {
-  NOT_PLAYING = "NOT_PLAYING",
-  PLAYING = "PLAYING",
+  NOT_PLAYING = 'NOT_PLAYING',
+  PLAYING = 'PLAYING',
 }
 export enum PlayerRole {
-  PAINTER = "PAINTER",
-  DEVIL = "DEVIL",
-  GUESSER = "GUESSER",
+  PAINTER = 'PAINTER',
+  DEVIL = 'DEVIL',
+  GUESSER = 'GUESSER',
 }
 export enum RoomStatus {
-  WAITING = "WAITING",
-  DRAWING = "DRAWING",
-  GUESSING = "GUESSING",
+  WAITING = 'WAITING',
+  DRAWING = 'DRAWING',
+  GUESSING = 'GUESSING',
 }
 
 export enum TimerType {
-  DRAWING = "DRAWING",
-  GUESSING = "GUESSING",
-  ENDING = "ENDING",
+  DRAWING = 'DRAWING',
+  GUESSING = 'GUESSING',
+  ENDING = 'ENDING',
 }

--- a/core/types/socket.types.ts
+++ b/core/types/socket.types.ts
@@ -1,11 +1,5 @@
-import { CRDTMessage, DrawingData } from "@/types/crdt.types";
-import {
-  Player,
-  PlayerRole,
-  Room,
-  RoomSettings,
-  TimerType,
-} from "@/types/game.types";
+import { CRDTMessage, DrawingData } from '@/types/crdt.types';
+import { Player, PlayerRole, Room, RoomSettings, TimerType } from '@/types/game.types';
 
 // 웹소켓 이벤트의 기본 응답 형식을 정의하는 제네릭 인터페이스
 // export interface SocketResponse<T = unknown> {
@@ -181,18 +175,9 @@ export type GameServerEvents = {
 // 게임 클라이언트 이벤트 타입 정의
 export type GameClientEvents = {
   reconnect: (request: ReconnectRequest) => void;
-  joinRoom: (
-    request: JoinRoomRequest,
-    callback: (response: JoinRoomResponse) => void
-  ) => void;
-  updateSettings: (
-    request: UpdateSettingsRequest,
-    callback: (response: UpdateSettingsResponse) => void
-  ) => void;
-  updatePlayerStatus: (
-    request: ReadyRequest,
-    callback: (response: ReadyResponse) => void
-  ) => void;
+  joinRoom: (request: JoinRoomRequest, callback: (response: JoinRoomResponse) => void) => void;
+  updateSettings: (request: UpdateSettingsRequest, callback: (response: UpdateSettingsResponse) => void) => void;
+  updatePlayerStatus: (request: ReadyRequest, callback: (response: ReadyResponse) => void) => void;
 };
 
 // 드로잉 서버 이벤트 타입 정의


### PR DESCRIPTION
## 📂 작업 내용

closes #109 

- [x] core 패키지 내 prettier 설정

## 💡 자세한 설명

* 코드 일관성을 위해 core 패키지에도 prettier 설정을 했습니다.
* 혹시 `control + S` 누른 후에 자신의 vscode prettier 설정이 우선시 되어 저장된다면 vscode에서 `Reload Window` 실행하면 core 폴더 내 prettier로 저장됩니다!!

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
