### PR TITLE
feat: Add random nickname generator

### DIFF
--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -11,8 +11,8 @@ import { GameService } from './game.service';
 import { UseFilters } from '@nestjs/common';
 import { WsExceptionFilter } from 'src/filters/ws-exception.filter';
 import { Player, Room, RoomSettings } from 'src/common/types/game.types';
-import { BadRequestException, GameAlreadyStartedException, RoomNotFoundException } from 'src/exceptions/game.exception';
-import { PlayerRole, RoomStatus } from 'src/common/enums/game.status.enum';
+import { BadRequestException } from 'src/exceptions/game.exception';
+import { PlayerRole } from 'src/common/enums/game.status.enum';
 import { TimerService } from 'src/common/services/timer.service';
 import { TimerType } from 'src/common/enums/game.timer.enum';
 
@@ -36,12 +36,6 @@ export class GameGateway implements OnGatewayDisconnect {
 
   @SubscribeMessage('joinRoom')
   async handleJoinRoom(@ConnectedSocket() client: Socket, @MessageBody() data: { roomId: string }) {
-    const roomStatus = await this.gameService.getRoomStatus(data.roomId);
-    if (!roomStatus) throw new RoomNotFoundException('Room not found');
-    if (roomStatus === RoomStatus.GUESSING || roomStatus === RoomStatus.DRAWING) {
-      throw new GameAlreadyStartedException('Cannot join room while game is in progress');
-    }
-
     const { room, roomSettings, player, players } = await this.gameService.joinRoom(data.roomId);
 
     client.data.playerId = player.playerId;

--- a/server/src/game/game.service.ts
+++ b/server/src/game/game.service.ts
@@ -9,6 +9,7 @@ import {
   BadRequestException,
   InsufficientPlayersException,
   ForbiddenException,
+  GameAlreadyStartedException,
 } from 'src/exceptions/game.exception';
 import { RoomStatus, PlayerStatus, PlayerRole, Difficulty } from 'src/common/enums/game.status.enum';
 import { ClovaClient } from 'src/common/clova-client';
@@ -50,6 +51,9 @@ export class GameService {
     ]);
 
     if (!room) throw new RoomNotFoundException();
+    if (room.status === RoomStatus.GUESSING || room.status === RoomStatus.DRAWING) {
+      throw new GameAlreadyStartedException('Cannot join room while game is in progress');
+    }
     if (!roomSettings) throw new RoomNotFoundException('Room settings not found');
     if (players.length >= roomSettings.maxPlayers) {
       throw new RoomFullException('Room is full');
@@ -60,7 +64,7 @@ export class GameService {
       playerId,
       role: null,
       status: PlayerStatus.NOT_PLAYING,
-      nickname: `Player ${players.length + 1}`,
+      nickname: this.generateNickname(),
       profileImage: null,
       score: 0,
     };
@@ -78,8 +82,47 @@ export class GameService {
     return { room, roomSettings, player, players: updatedPlayers };
   }
 
-  getRoomStatus(roomId: string) {
-    return this.gameRepository.getRoomStatus(roomId);
+  private generateNickname() {
+    const adjectives = [
+      '귀여운',
+      '용감한',
+      '즐거운',
+      '행복한',
+      '웃는',
+      '똑똑한',
+      '현명한',
+      '멋진',
+      '활발한',
+      '착한',
+      '신나는',
+      '재미있는',
+      '발랄한',
+      '영리한',
+      '친절한',
+    ];
+
+    const nouns = [
+      '판다',
+      '호랑이',
+      '토끼',
+      '강아지',
+      '고양이',
+      '펭귄',
+      '사자',
+      '기린',
+      '코끼리',
+      '곰돌이',
+      '여우',
+      '늑대',
+      '참새',
+      '독수리',
+      '돌고래',
+    ];
+
+    const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
+    const noun = nouns[Math.floor(Math.random() * nouns.length)];
+
+    return `${adj} ${noun}`;
   }
 
   async reconnect(roomId: string, playerId: string) {


### PR DESCRIPTION
## 📂 작업 내용

closes #169 

- [x] 랜덤 닉네임 생성

## 💡 자세한 설명

- 형용사와 명사 조합으로 닉네임 자동 생성
- 15개의 형용사, 15개의 명사로 총 225개 조합 가능
- 예시: '귀여운 판다', '용감한 호랑이'

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
