### PR TITLE
feat: Apply random profile images with DiceBear API

### DIFF
--- a/server/src/game/game.service.ts
+++ b/server/src/game/game.service.ts
@@ -56,12 +56,13 @@ export class GameService {
     }
 
     const playerId = v4();
+    const nickname = this.generateNickname();
     const player: Player = {
       playerId,
       role: null,
       status: PlayerStatus.NOT_PLAYING,
-      nickname: `Player ${players.length + 1}`,
-      profileImage: null,
+      nickname,
+      profileImage: `https://api.dicebear.com/9.x/pixel-art/svg?seed=${nickname}`,
       score: 0,
     };
 
@@ -78,8 +79,47 @@ export class GameService {
     return { room, roomSettings, player, players: updatedPlayers };
   }
 
-  getRoomStatus(roomId: string) {
-    return this.gameRepository.getRoomStatus(roomId);
+  private generateNickname() {
+    const adjectives = [
+      '귀여운',
+      '용감한',
+      '즐거운',
+      '행복한',
+      '웃는',
+      '똑똑한',
+      '현명한',
+      '멋진',
+      '활발한',
+      '착한',
+      '신나는',
+      '재미있는',
+      '발랄한',
+      '영리한',
+      '친절한',
+    ];
+
+    const nouns = [
+      '판다',
+      '호랑이',
+      '토끼',
+      '강아지',
+      '고양이',
+      '펭귄',
+      '사자',
+      '기린',
+      '코끼리',
+      '곰돌이',
+      '여우',
+      '늑대',
+      '참새',
+      '독수리',
+      '돌고래',
+    ];
+
+    const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
+    const noun = nouns[Math.floor(Math.random() * nouns.length)];
+
+    return `${adj} ${noun}`;
   }
 
   async reconnect(roomId: string, playerId: string) {


### PR DESCRIPTION
## 📂 작업 내용

closes #173 

- [x] 랜덤 프로필 사진 적용

## 💡 자세한 설명

- 새 플레이어를 위한 랜덤 아바타 생성 기능 구현
- 정적 프로필 이미지를 DiceBear 픽셀 아트로 교체

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
