### PR TITLE
fix: Remove duplicate points in CRDT

### DIFF
--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -1,4 +1,4 @@
-import { RefObject, useCallback } from 'react';
+import { RefObject, useCallback, useRef } from 'react';
 import {
   Point,
   CRDTMessage,
@@ -85,12 +85,15 @@ export const useDrawing = (
 ) => {
   const state = useDrawingState(options);
   const operation = useDrawingOperation(canvasRef, state);
+  const lastPoint = useRef<Point | null>(null);
 
   const startDrawing = useCallback(
     (point: Point): CRDTUpdateMessage | null => {
       if (state.checkInkAvailability() === false || !state.crdtRef.current) return null;
 
       state.currentStrokeIdsRef.current = [];
+      lastPoint.current = point;
+
       const drawingData =
         state.drawingMode === DRAWING_MODE.FILL
           ? operation.floodFill(Math.floor(point.x), Math.floor(point.y))
@@ -118,27 +121,19 @@ export const useDrawing = (
 
   const continueDrawing = useCallback(
     (point: Point): CRDTUpdateMessage | null => {
-      if (!state.crdtRef.current || state.inkRemaining <= 0) return null;
+      if (!state.crdtRef.current || !lastPoint.current || state.inkRemaining <= 0) return null;
       if (state.drawingMode === DRAWING_MODE.FILL) return null;
+      if (lastPoint.current.x === point.x && lastPoint.current.y === point.y) return null;
 
-      const lastStrokeId = state.currentStrokeIdsRef.current[state.currentStrokeIdsRef.current.length - 1];
-      const lastStroke = state.crdtRef.current.strokes.find((s) => s.id === lastStrokeId);
-      if (!lastStroke) return null;
-
-      const updatedDrawing = {
-        ...lastStroke.stroke,
-        points: [...lastStroke.stroke.points, point],
+      const drawingData = {
+        points: [lastPoint.current, point],
+        style: operation.getCurrentStyle(),
       };
 
-      const lastPoint = lastStroke.stroke.points[lastStroke.stroke.points.length - 1];
-      const pixelsUsed = Math.ceil(
-        Math.sqrt(Math.pow(point.x - lastPoint.x, 2) + Math.pow(point.y - lastPoint.y, 2)) * state.brushSize,
-      );
-      state.setInkRemaining((prev: number) => Math.max(0, prev - pixelsUsed));
-
-      const strokeId = state.crdtRef.current.addStroke(updatedDrawing);
+      const strokeId = state.crdtRef.current.addStroke(drawingData);
       state.currentStrokeIdsRef.current.push(strokeId);
-      operation.drawStroke(updatedDrawing);
+      operation.drawStroke(drawingData);
+      lastPoint.current = point;
 
       return {
         type: CRDTMessageTypes.UPDATE,
@@ -152,24 +147,34 @@ export const useDrawing = (
   );
 
   const stopDrawing = useCallback(() => {
-    if (!state.crdtRef.current || state.currentStrokeIdsRef.current.length === 0) return;
+    if (!state.crdtRef.current || !lastPoint.current || state.currentStrokeIdsRef.current.length === 0) return;
 
     if (state.historyPointerRef.current < state.strokeHistoryRef.current.length - 1) {
       state.strokeHistoryRef.current = state.strokeHistoryRef.current.slice(0, state.historyPointerRef.current + 1);
     }
 
-    const lastStrokeId = state.currentStrokeIdsRef.current[state.currentStrokeIdsRef.current.length - 1];
-    const lastStroke = state.crdtRef.current.strokes.find((s) => s.id === lastStrokeId);
+    const allPoints: Point[] = [];
+    state.currentStrokeIdsRef.current.forEach((strokeId) => {
+      const stroke = state.crdtRef.current!.strokes.find((s) => s.id === strokeId);
+      if (stroke) {
+        allPoints.push(...stroke.stroke.points);
+      }
+    });
 
-    if (!lastStroke) return;
+    const drawingData = {
+      points: allPoints,
+      style: operation.getCurrentStyle(),
+    };
 
     state.strokeHistoryRef.current.push({
       strokeIds: [...state.currentStrokeIdsRef.current],
       isLocal: true,
-      drawingData: lastStroke.stroke,
+      drawingData,
     });
+
     state.historyPointerRef.current = state.strokeHistoryRef.current.length - 1;
 
+    lastPoint.current = null;
     state.currentStrokeIdsRef.current = [];
     state.updateHistoryState();
   }, [state]);
@@ -217,26 +222,25 @@ export const useDrawing = (
       nextEntry = state.strokeHistoryRef.current[state.historyPointerRef.current + 1];
     }
 
-    if (!nextEntry?.isLocal) return null;
+    if (!nextEntry?.isLocal || !nextEntry.drawingData) return null;
 
-    const updates = nextEntry.strokeIds.map((): CRDTUpdateMessage => {
-      const strokeId = state.crdtRef.current!.addStroke(nextEntry.drawingData);
-      return {
-        type: CRDTMessageTypes.UPDATE,
-        state: {
-          key: strokeId,
-          register: state.crdtRef.current!.state[strokeId],
-        },
-      };
-    });
+    const strokeId = state.crdtRef.current.addStroke(nextEntry.drawingData);
 
-    nextEntry.strokeIds = updates.map((update) => update.state.key);
+    const update: CRDTUpdateMessage = {
+      type: CRDTMessageTypes.UPDATE,
+      state: {
+        key: strokeId,
+        register: state.crdtRef.current.state[strokeId],
+      },
+    };
+
+    nextEntry.strokeIds = [strokeId];
 
     state.historyPointerRef.current++;
     state.updateHistoryState();
     operation.redrawCanvas();
 
-    return updates;
+    return [update];
   }, [state, operation]);
 
   const applyDrawing = useCallback(
@@ -258,11 +262,15 @@ export const useDrawing = (
         const isLocalUpdate = peerId === state.currentPlayerId;
 
         if (!state.crdtRef.current.mergeRegister(key, register) || isLocalUpdate) return;
-        operation.redrawCanvas();
 
         const stroke = register[2];
-        // stroke가 null이 아닌 경우 (삭제되지 않은 경우) 히스토리 추가
-        if (!stroke) return;
+        if (!stroke) {
+          operation.redrawCanvas();
+          return;
+        }
+
+        operation.drawStroke(stroke);
+
         if (state.historyPointerRef.current < state.strokeHistoryRef.current.length - 1) {
           state.strokeHistoryRef.current = state.strokeHistoryRef.current.slice(0, state.historyPointerRef.current + 1);
         }
@@ -276,7 +284,7 @@ export const useDrawing = (
         state.updateHistoryState();
       }
     },
-    [state.currentPlayerId, operation.redrawCanvas, state.updateHistoryState, roomStatus],
+    [state.currentPlayerId, operation, roomStatus],
   );
 
   const getAllDrawingData = useCallback((): CRDTSyncMessage | null => {

--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -85,14 +85,14 @@ export const useDrawing = (
 ) => {
   const state = useDrawingState(options);
   const operation = useDrawingOperation(canvasRef, state);
-  const lastPoint = useRef<Point | null>(null);
+  const currentDrawingPoints = useRef<Point[]>([]);
 
   const startDrawing = useCallback(
     (point: Point): CRDTUpdateMessage | null => {
       if (state.checkInkAvailability() === false || !state.crdtRef.current) return null;
 
       state.currentStrokeIdsRef.current = [];
-      lastPoint.current = point;
+      currentDrawingPoints.current = [point];
 
       const drawingData =
         state.drawingMode === DRAWING_MODE.FILL
@@ -121,19 +121,24 @@ export const useDrawing = (
 
   const continueDrawing = useCallback(
     (point: Point): CRDTUpdateMessage | null => {
-      if (!state.crdtRef.current || !lastPoint.current || state.inkRemaining <= 0) return null;
+      if (!state.crdtRef.current || currentDrawingPoints.current.length === 0 || state.inkRemaining <= 0) return null;
       if (state.drawingMode === DRAWING_MODE.FILL) return null;
-      if (lastPoint.current.x === point.x && lastPoint.current.y === point.y) return null;
+
+      const lastPoint = currentDrawingPoints.current[currentDrawingPoints.current.length - 1];
+      if (lastPoint.x === point.x && lastPoint.y === point.y) return null;
+
+      currentDrawingPoints.current.push(point);
 
       const drawingData = {
-        points: [lastPoint.current, point],
+        points: [...currentDrawingPoints.current],
         style: operation.getCurrentStyle(),
       };
 
       const strokeId = state.crdtRef.current.addStroke(drawingData);
       state.currentStrokeIdsRef.current.push(strokeId);
       operation.drawStroke(drawingData);
-      lastPoint.current = point;
+
+      currentDrawingPoints.current = [point];
 
       return {
         type: CRDTMessageTypes.UPDATE,
@@ -147,7 +152,8 @@ export const useDrawing = (
   );
 
   const stopDrawing = useCallback(() => {
-    if (!state.crdtRef.current || !lastPoint.current || state.currentStrokeIdsRef.current.length === 0) return;
+    if (!state.crdtRef.current || !currentDrawingPoints.current || state.currentStrokeIdsRef.current.length === 0)
+      return;
 
     if (state.historyPointerRef.current < state.strokeHistoryRef.current.length - 1) {
       state.strokeHistoryRef.current = state.strokeHistoryRef.current.slice(0, state.historyPointerRef.current + 1);
@@ -174,7 +180,7 @@ export const useDrawing = (
 
     state.historyPointerRef.current = state.strokeHistoryRef.current.length - 1;
 
-    lastPoint.current = null;
+    currentDrawingPoints.current = [];
     state.currentStrokeIdsRef.current = [];
     state.updateHistoryState();
   }, [state]);

--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -127,6 +127,11 @@ export const useDrawing = (
       const lastPoint = currentDrawingPoints.current[currentDrawingPoints.current.length - 1];
       if (lastPoint.x === point.x && lastPoint.y === point.y) return null;
 
+      const pixelsUsed = Math.ceil(
+        Math.sqrt(Math.pow(point.x - lastPoint.x, 2) + Math.pow(point.y - lastPoint.y, 2)) * state.brushSize,
+      );
+      state.setInkRemaining((prev: number) => Math.max(0, prev - pixelsUsed));
+
       currentDrawingPoints.current.push(point);
 
       const drawingData = {

--- a/client/src/hooks/canvas/useDrawingOperation.ts
+++ b/client/src/hooks/canvas/useDrawingOperation.ts
@@ -82,6 +82,8 @@ export const useDrawingOperation = (
     ctx.fillStyle = style.color;
     ctx.lineWidth = style.width;
     ctx.beginPath();
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
 
     if (points.length === 1) {
       const point = points[0];


### PR DESCRIPTION
## 📂 작업 내용

closes #176 

- [x] CRDT 중복 포인트 제거

## 💡 자세한 설명

* `useDrawing` 훅에 `currentDrawingPoints` ref를 추가하여 현재 그리기 중인 포인트들을 저장했습니다.
* `continueDrawing` 메서드에서 이전 포인트와 새로운 포인트의 좌표를 비교하여 중복된 포인트를 무시하도록 수정했습니다.
* `continueDrawing` 메서드에서 `currentDrawingPoints`를 사용하여 현재 그리기의 포인트들을 관리하고, 새로운 스트로크를 생성할 때 이 포인트들을 사용하도록 했습니다. 
  * **새로운 onMouseMove 이벤트 발생 이전에 배열 초기화 -> 중복 좌표 저장 X**
* `stopDrawing` 메서드에서는 `currentStrokeIdsRef`에 저장된 모든 스트로크의 포인트들을 수집하여 하나의 drawingData로 만들어 히스토리에 저장합니다.

### 중복 픽셀 제거 전

* CPU 성능 20x 감속 환경

![화면-기록-2024-12-02-오후-2 59 59](https://github.com/user-attachments/assets/3dcdbb99-a22f-4416-8297-8110bee9c407)

### 중복 픽셀 제거 후

* CPU 성능 20x 감속 환경

![화면-기록-2024-12-02-오후-3 01 12](https://github.com/user-attachments/assets/c5ec8c2a-8057-421d-a480-999149ae3f36)

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
