### PR TITLE
feat: Implement LobbyPage shortcutKey

### DIFF
--- a/client/src/components/chat/Chat.tsx
+++ b/client/src/components/chat/Chat.tsx
@@ -1,7 +1,8 @@
-import { FormEvent, useMemo, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PlayerRole, RoomStatus, type ChatResponse } from '@troublepainter/core';
 import { ChatBubble } from '@/components/chat/ChatBubbleUI';
 import { Input } from '@/components/ui/Input';
+import { SHORTCUT_KEY } from '@/constants/shortcutKey';
 import { chatSocketHandlers } from '@/handlers/socket/chatSocket.handler';
 import { gameSocketHandlers } from '@/handlers/socket/gameSocket.handler';
 import { useChatSocket } from '@/hooks/socket/useChatSocket';
@@ -11,6 +12,8 @@ import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 
 export const Chat = () => {
   const [inputMessage, setInputMessage] = useState('');
+  const [isInputActive, setIsInputActive] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const { messages, isConnected, currentPlayerId } = useChatSocket();
   const { players, room, roundAssignedRole } = useGameSocketStore();
   const { actions } = useChatSocketStore();
@@ -44,6 +47,23 @@ export const Chat = () => {
     return ispainters && isDrawing;
   }, [roundAssignedRole, room?.status]);
 
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key !== SHORTCUT_KEY.CHAT) return;
+      const action = isInputActive && inputMessage.trim() === '' ? 'blur' : 'focus';
+      inputRef.current?.[action]();
+      setIsInputActive(action === 'focus');
+    },
+    [isInputActive, inputMessage],
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
+
   return (
     <div className="relative flex h-full w-full flex-col">
       <div ref={containerRef} className="flex h-full flex-col gap-2 overflow-y-auto">
@@ -67,6 +87,7 @@ export const Chat = () => {
 
       <form onSubmit={handleSubmit} className="mt-1 w-full">
         <Input
+          ref={inputRef}
           value={inputMessage}
           onChange={(e) => setInputMessage(e.target.value)}
           placeholder="메시지를 입력하세요"

--- a/client/src/components/chat/Chat.tsx
+++ b/client/src/components/chat/Chat.tsx
@@ -12,7 +12,6 @@ import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 
 export const Chat = () => {
   const [inputMessage, setInputMessage] = useState('');
-  const [isInputActive, setIsInputActive] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const { messages, isConnected, currentPlayerId } = useChatSocket();
   const { players, room, roundAssignedRole } = useGameSocketStore();
@@ -49,12 +48,20 @@ export const Chat = () => {
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
-      if (event.key !== SHORTCUT_KEY.CHAT) return;
-      const action = isInputActive && inputMessage.trim() === '' ? 'blur' : 'focus';
-      inputRef.current?.[action]();
-      setIsInputActive(action === 'focus');
+      if (event.key !== SHORTCUT_KEY.CHAT || !inputRef.current) return;
+
+      // 현재 포커스된 요소가 없거나, 포커스된 요소가 body라면 input을 포커싱
+      const isNoFocusedElement = !document.activeElement || document.activeElement === document.body;
+
+      if (isNoFocusedElement) {
+        inputRef.current?.focus();
+      } else if (inputMessage.trim() === '') {
+        inputRef.current.blur();
+      } else {
+        inputRef.current?.focus();
+      }
     },
-    [isInputActive, inputMessage],
+    [inputMessage],
   );
 
   useEffect(() => {

--- a/client/src/components/chat/ChatBubbleUI.tsx
+++ b/client/src/components/chat/ChatBubbleUI.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/cn';
 
 const chatBubbleVariants = cva(
-  'px-2.5 inline-flex max-w-[85%] items-center justify-center rounded-lg border-2 border-violet-950 text-violet-950 text-base min-h-8 lg:text-lg 2xl:py-0.5 2xl:text-xl',
+  'break-all px-2.5 inline-flex max-w-[85%] items-center justify-center rounded-lg border-2 border-violet-950 text-violet-950 text-base min-h-8 lg:text-lg 2xl:py-0.5 2xl:text-xl',
   {
     variants: {
       variant: {

--- a/client/src/components/lobby/InviteButton.tsx
+++ b/client/src/components/lobby/InviteButton.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/Button';
+import { SHORTCUT_KEY } from '@/constants/shortcutKey';
 import { useToastStore } from '@/stores/toast.store';
 import { cn } from '@/utils/cn';
 
@@ -29,6 +30,18 @@ export const InviteButton = () => {
       });
     }
   };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === SHORTCUT_KEY.GAME_INVITE) {
+        void handleCopyInvite();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
 
   return (
     <Button

--- a/client/src/components/player/PlayerCardList.tsx
+++ b/client/src/components/player/PlayerCardList.tsx
@@ -19,6 +19,7 @@ const PlayerCardList = () => {
 
         return (
           <PlayerCard
+            profileImage={player.profileImage}
             key={player.playerId}
             nickname={player.nickname}
             status={player.status}

--- a/client/src/components/setting/Setting.tsx
+++ b/client/src/components/setting/Setting.tsx
@@ -1,6 +1,7 @@
-import { HTMLAttributes, useEffect, useState } from 'react';
+import { HTMLAttributes, KeyboardEvent, useEffect, useState } from 'react';
 import { RoomSettings } from '@troublepainter/core';
 import Dropdown from '@/components/ui/Dropdown';
+import { SHORTCUT_KEY } from '@/constants/shortcutKey';
 import { gameSocketHandlers } from '@/handlers/socket/gameSocket.handler';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 import { cn } from '@/utils/cn';
@@ -11,28 +12,25 @@ interface RoomSettingItem {
   key: SettingKey;
   label: string;
   options: number[];
+  shortcutKey: KeyboardEvent['key'];
 }
 
 export const ROOM_SETTINGS: RoomSettingItem[] = [
-  { label: '라운드 수', key: 'totalRounds', options: [3, 5] },
-  { label: '최대 플레이어 수', key: 'maxPlayers', options: [4, 5] },
-  { label: '제한 시간', key: 'drawTime', options: [15, 20, 25, 30] },
+  { label: '라운드 수', key: 'totalRounds', options: [3, 5], shortcutKey: SHORTCUT_KEY.DROPDOWN_TOTAL_ROUNDS },
+  { label: '최대 플레이어 수', key: 'maxPlayers', options: [4, 5], shortcutKey: SHORTCUT_KEY.DROPDOWN_MAX_PLAYERS },
+  { label: '제한 시간', key: 'drawTime', options: [15, 20, 25, 30], shortcutKey: SHORTCUT_KEY.DROPDOWN_DRAW_TIME },
   //{ label: '픽셀 수', key: 'maxPixels', options: [300, 500] },
 ];
 
 const Setting = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
   const { roomSettings, isHost, actions } = useGameSocketStore();
-
-  const [selectedValues, setSelectedValues] = useState<RoomSettings>({
-    totalRounds: 5,
-    maxPlayers: 5,
-    drawTime: 30,
-  });
-
-  useEffect(() => {
-    if (!roomSettings) return;
-    setSelectedValues(roomSettings);
-  }, [roomSettings]);
+  const [selectedValues, setSelectedValues] = useState<RoomSettings>(
+    roomSettings ?? {
+      totalRounds: 5,
+      maxPlayers: 5,
+      drawTime: 30,
+    },
+  );
 
   useEffect(() => {
     if (!isHost || !selectedValues || !selectedValues.drawTime) return;
@@ -40,9 +38,9 @@ const Setting = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
       settings: { ...selectedValues, drawTime: selectedValues.drawTime + 5 },
     });
     actions.updateRoomSettings(selectedValues);
-  }, [selectedValues]);
+  }, [isHost, selectedValues]);
 
-  const handleChange = (key: SettingKey) => (value: string) => {
+  const handleChange = (key: SettingKey, value: string) => {
     setSelectedValues((prev) => ({
       ...prev,
       [key]: Number(value),
@@ -62,16 +60,17 @@ const Setting = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
       {/* Setting content */}
       <div className="flex min-h-[16.125rem] items-center justify-center bg-violet-200 sm:min-h-[18.56rem] sm:rounded-b-xl sm:px-6">
         <div className="flex min-h-[13.8rem] w-full flex-col items-center justify-center gap-4 border-0 border-violet-950 bg-violet-50 p-4 text-xl sm:h-auto sm:rounded-[0.625rem] sm:border-2 lg:gap-6 lg:text-2xl">
-          {ROOM_SETTINGS.map(({ label, key, options }) => (
+          {ROOM_SETTINGS.map(({ label, key, options, shortcutKey }) => (
             <div key={label} className="flex w-full max-w-80 items-center justify-between lg:max-w-[80%]">
               <span>{label}</span>
               {!isHost ? (
                 <span>{roomSettings?.[key] || ''}</span>
               ) : (
                 <Dropdown
+                  shortcutKey={shortcutKey}
                   options={options.map((option) => option.toString())}
                   selectedValue={selectedValues?.[key]?.toString() || ''}
-                  handleChange={handleChange(key)}
+                  handleChange={(value) => handleChange(key, value)}
                   className="h-7 w-[30%] min-w-[4.25rem] text-xl sm:min-w-28 lg:h-auto lg:text-2xl"
                 />
               )}

--- a/client/src/components/ui/Dropdown.tsx
+++ b/client/src/components/ui/Dropdown.tsx
@@ -7,18 +7,21 @@ export interface DropdownProps extends HTMLAttributes<HTMLDivElement> {
   options: string[];
   handleChange: (value: string) => void;
   selectedValue: string;
+  shortcutKey?: KeyboardEvent['key'];
 }
 
-const Dropdown = ({ options, handleChange, selectedValue, className, ...props }: DropdownProps) => {
-  const { isOpen, toggleDropdown, handleOptionClick, dropdownRef } = useDropdown({
+const Dropdown = ({ options, handleChange, selectedValue, shortcutKey, className, ...props }: DropdownProps) => {
+  const { isOpen, toggleDropdown, handleOptionClick, dropdownRef, optionRefs, handleOptionKeyDown } = useDropdown({
     handleChange,
+    shortcutKey,
+    options,
   });
 
   return (
     <div className={cn('relative rounded-lg bg-eastbay-50 text-2xl', className)} ref={dropdownRef} {...props}>
       <button
         onClick={toggleDropdown}
-        className="flex h-full w-full items-center justify-between rounded-lg border-2 border-violet-950 px-2"
+        className="flex h-full w-full items-center justify-between rounded-lg border-2 border-violet-950 px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2"
       >
         <span className="w-full text-center">{selectedValue}</span>
         <img
@@ -39,7 +42,9 @@ const Dropdown = ({ options, handleChange, selectedValue, className, ...props }:
           {options.map((option, index) => (
             <button
               key={index}
+              ref={(item) => (optionRefs.current[index] = item)}
               onClick={() => handleOptionClick(option)}
+              onKeyDown={handleOptionKeyDown}
               className={cn(
                 'w-full p-2 text-center transition-colors duration-200 ease-in-out hover:bg-violet-100 focus:bg-violet-200',
               )}

--- a/client/src/components/ui/Input.tsx
+++ b/client/src/components/ui/Input.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, useId } from 'react';
+import { InputHTMLAttributes, forwardRef, useId } from 'react';
 import { cn } from '@/utils/cn';
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -6,7 +6,7 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
 }
 
-const Input = ({ className, label, ...props }: InputProps) => {
+const Input = forwardRef<HTMLInputElement, InputProps>(({ className, label, ...props }, ref) => {
   const inputId = useId();
 
   return (
@@ -17,6 +17,7 @@ const Input = ({ className, label, ...props }: InputProps) => {
       <input
         id={inputId}
         type="text"
+        ref={ref}
         className={cn(
           'h-11 w-full rounded-lg border-2 border-violet-950 px-4 text-base text-violet-950 placeholder:text-eastbay-500 focus:border-violet-500 focus:outline-none lg:h-12 lg:text-lg 2xl:h-14 2xl:text-xl',
           className,
@@ -25,6 +26,8 @@ const Input = ({ className, label, ...props }: InputProps) => {
       />
     </>
   );
-};
+});
+
+Input.displayName = 'Input';
 
 export { Input };

--- a/client/src/constants/shortcutKey.ts
+++ b/client/src/constants/shortcutKey.ts
@@ -1,0 +1,8 @@
+export const SHORTCUT_KEY = {
+  DROPDOWN_TOTAL_ROUNDS: 'q',
+  DROPDOWN_MAX_PLAYERS: 'w',
+  DROPDOWN_DRAW_TIME: 'e',
+  CHAT: 'Enter',
+  GAME_START: 's',
+  GAME_INVITE: 'i',
+};

--- a/client/src/hooks/useDropdown.ts
+++ b/client/src/hooks/useDropdown.ts
@@ -31,7 +31,8 @@ interface UseDropdown {
  *     focusedIndex,     // 현재 포커스된 옵션의 인덱스
  *     toggleDropdown,   // 드롭다운 토글 함수
  *     handleOptionClick,// 옵션 클릭 핸들러
- *     dropdownRef       // 드롭다운 요소의 ref
+ *     dropdownRef,      // 드롭다운 요소의 ref
+ *     handleOptionKeyDown // 옵션 키보드 이벤트 핸들러
  *   } = useDropdown({
  *     shortcutKey: 'Q',
  *     handleChange: (value) => console.log(value),
@@ -46,13 +47,15 @@ interface UseDropdown {
  *       {isOpen && (
  *         <ul>
  *           {options.map((option, index) => (
- *             <li
+ *             <button
  *               key={option}
+ *               ref={(el) => (optionRefs.current[index] = el)}
  *               data-focused={index === focusedIndex}
  *               onClick={() => handleOptionClick(option)}
+ *               onKeyDown={handleOptionKeyDown}
  *             >
  *               {option}
- *             </li>
+ *             </button>
  *           ))}
  *         </ul>
  *       )}
@@ -63,11 +66,12 @@ interface UseDropdown {
  *
  * @remarks
  * 이 훅은 다음과 같은 기능을 제공합니다:
- * - 단축키를 통한 드롭다운 열기
+ * - 단축키를 통한 드롭다운 열기/닫기
  * - 키보드 방향키(상하)를 통한 옵션 탐색
  * - Enter키를 통한 옵션 선택
  * - Escape키를 통한 드롭다운 닫기
  * - 외부 클릭 시 자동으로 드롭다운 닫기
+ * - 접근성을 위한 키보드 탐색 지원
  *
  * @category Hooks
  */

--- a/client/src/hooks/useDropdown.ts
+++ b/client/src/hooks/useDropdown.ts
@@ -1,83 +1,147 @@
-import { useEffect, useRef, useState } from 'react';
+import { KeyboardEvent as ReactKeyboardEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 /**
- * `useDropdown` 훅에 전달할 옵션 객체의 인터페이스입니다.
+ * 드롭다운을 제어하기 위한 커스텀 훅의 Props 인터페이스입니다.
  */
 interface UseDropdown {
+  /** 드롭다운을 열고 닫을 수 있는 키보드 단축키 입니다. */
+  shortcutKey?: string;
+
   /**
-   * 선택된 값을 처리하는 콜백 함수입니다.
-   *
-   * @param value - 선택된 값 입니다.
+   * 옵션이 선택되었을 때 호출되는 콜백 함수입니다.
+   * @param value - 선택된 옵션의 값
    */
   handleChange: (value: string) => void;
+
+  /** 드롭다운에 표시될 옵션들의 배열입니다. */
+  options: string[];
 }
 
 /**
- * 드롭다운의 상태를 관리하는 커스텀 훅입니다.
+ * 드롭다운의 상태와 동작을 관리하는 커스텀 훅입니다.
  *
- * @param handleChange - 옵션이 선택되었을 때 호출되는 함수입니다.
- *                       선택된 값을 인자로 받습니다.
+ * @param props - 드롭다운 설정을 위한 객체
+ * @returns 드롭다운 제어에 필요한 상태와 함수들을 포함하는 객체
  *
- * @returns 다음과 같은 속성을 가진 객체를 반환합니다:
- * - `isOpen`: 드롭다운이 열려있는지 닫혀있는지 나타내는 불리언 값입니다.
- * - `toggleDropdown`: 드롭다운의 열림/닫힘 상태를 토글하는 함수입니다.
- * - `handleOptionClick`: 드롭다운 옵션이 선택되었을 때 호출되는 함수입니다.
- * - `dropdownRef`: 드롭다운 컴포넌트의 DOM 요소를 참조하는 React Ref입니다. 바깥 영역 클릭 감지에 사용됩니다.
- * 
- * @example 
- * const { isOpen, toggleDropdown, handleOptionClick } = useDropdown({
-    handleChange,
-  });
-
-  return (
-    <>
-      <button
-        onClick={toggleDropdown}
-      >
-        {isOpen ? '드롭다운 닫기' : '드롭다운 열기'}
-      </button>
-
-      {isOpen && options.map((option) => (
-        <button
-          key={option.id}
-          onClick={() => handleOptionClick(option.value)}
-        >
-          {option.value}
-        </button>
-      ))}
-    </>
-  );
+ * @example
+ * ```tsx
+ * const MyDropdown = () => {
+ *   const {
+ *     isOpen,           // 드롭다운의 열림/닫힘 상태
+ *     focusedIndex,     // 현재 포커스된 옵션의 인덱스
+ *     toggleDropdown,   // 드롭다운 토글 함수
+ *     handleOptionClick,// 옵션 클릭 핸들러
+ *     dropdownRef       // 드롭다운 요소의 ref
+ *   } = useDropdown({
+ *     shortcutKey: 'Q',
+ *     handleChange: (value) => console.log(value),
+ *     options: ['옵션1', '옵션2', '옵션3']
+ *   });
+ *
+ *   return (
+ *     <div ref={dropdownRef}>
+ *       <button onClick={toggleDropdown}>
+ *         {isOpen ? '닫기' : '열기'}
+ *       </button>
+ *       {isOpen && (
+ *         <ul>
+ *           {options.map((option, index) => (
+ *             <li
+ *               key={option}
+ *               data-focused={index === focusedIndex}
+ *               onClick={() => handleOptionClick(option)}
+ *             >
+ *               {option}
+ *             </li>
+ *           ))}
+ *         </ul>
+ *       )}
+ *     </div>
+ *   );
+ * }
+ * ```
+ *
+ * @remarks
+ * 이 훅은 다음과 같은 기능을 제공합니다:
+ * - 단축키를 통한 드롭다운 열기
+ * - 키보드 방향키(상하)를 통한 옵션 탐색
+ * - Enter키를 통한 옵션 선택
+ * - Escape키를 통한 드롭다운 닫기
+ * - 외부 클릭 시 자동으로 드롭다운 닫기
+ *
  * @category Hooks
  */
 
-export const useDropdown = ({ handleChange }: UseDropdown) => {
+export const useDropdown = ({ shortcutKey, handleChange, options }: UseDropdown) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
   const dropdownRef = useRef<HTMLDivElement>(null);
-
-  const toggleDropdown = () => setIsOpen((prev) => !prev);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const handleOptionClick = (value: string) => {
     setIsOpen(false);
+    setFocusedIndex(-1);
     handleChange(value);
   };
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (shortcutKey && event.key.toLowerCase() === shortcutKey.toLowerCase()) {
+        setIsOpen((prev) => !prev);
+        setFocusedIndex(-1);
+        return;
       }
-    };
 
+      if (!isOpen) return;
+
+      if (event.key === 'ArrowDown') {
+        setFocusedIndex((prev) => (prev + 1) % options.length);
+      } else if (event.key === 'ArrowUp') {
+        setFocusedIndex((prev) => (prev - 1 + options.length) % options.length);
+      } else if (event.key === 'Escape') {
+        setIsOpen(false);
+        setFocusedIndex(-1);
+      }
+    },
+    [shortcutKey, isOpen, options.length],
+  );
+
+  const handleOptionKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' && focusedIndex >= 0) {
+      event.stopPropagation();
+      handleOptionClick(options[focusedIndex]);
+    }
+  };
+
+  const handleClickOutside = useCallback((event: MouseEvent) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      setIsOpen(false);
+      setFocusedIndex(-1);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (focusedIndex >= 0 && optionRefs.current[focusedIndex]) {
+      optionRefs.current[focusedIndex]?.focus();
+    }
+  }, [focusedIndex]);
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
     document.addEventListener('mousedown', handleClickOutside);
     return () => {
+      document.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, []);
+  }, [handleKeyDown, handleClickOutside]);
 
   return {
     isOpen,
-    toggleDropdown,
+    focusedIndex,
+    toggleDropdown: () => setIsOpen((prev) => !prev),
     handleOptionClick,
     dropdownRef,
+    optionRefs,
+    handleOptionKeyDown,
   };
 };

--- a/client/src/hooks/useStartButton.tsx
+++ b/client/src/hooks/useStartButton.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
+import { SHORTCUT_KEY } from '@/constants/shortcutKey';
 import { gameSocketHandlers } from '@/handlers/socket/gameSocket.handler';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 
@@ -29,10 +30,22 @@ export const useGameStart = () => {
     return START_BUTTON_STATUS.CAN_START;
   }, [isHost, players.length]);
 
-  const handleStartGame = () => {
+  const handleStartGame = useCallback(() => {
     if (!room || buttonConfig.disabled || !room.roomId || !currentPlayerId) return;
     void gameSocketHandlers.gameStart();
-  };
+  }, [room, buttonConfig.disabled, room?.roomId, currentPlayerId]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === SHORTCUT_KEY.GAME_START) {
+        handleStartGame();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleStartGame]);
 
   return {
     isHost,


### PR DESCRIPTION
## 📂 작업 내용

closes #174 

- [x]  라운드 수 필드 선택 단축키(Q)
- [x] 최대 플레이어 수 필드 선택 단축키(W)
- [x] 제한 시간 필드 선택 단축키(E)
- [x] 채팅 단축키 (Enter)
- [x] 게임 시작 단축키(S)
- [x] 초대 단축키(I) 

## 💡 자세한 설명

### 1. 게임 세팅 단축키 (Q, W, E) 
- 이벤트를 document에 부착 
- 라운드 수 (Q), 최대 플레이어 수(W), 제한 시간(E) 을 눌러 드롭다운을 열고 닫을 수 있음  

### 2. 드롭다운 onKeyDown 속성 추가
- 드롭다운 메뉴들에 대해 "Enter" 키보드 이벤트 등록하여 메뉴 선택 
- ArrowDown, ArrowUp, Escape 키보드 이벤트를 등록하여 드롭다운 메뉴들 화살표로 이동, 드롭다운 메뉴 닫기 가능 

### 3. Chat, StartButton, InviteButton 단축키(Enter, S, I)

## 📗 참고 자료 & 구현 결과 (선택)

![shortcut](https://github.com/user-attachments/assets/16a508e2-4878-4d7e-8e39-b5453c2a7aa6)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

게임페이지 단축키 구현 

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
