### PR TITLE
feat: Initialize game when player leaves room

### DIFF
--- a/server/src/common/enums/game.status.enum.ts
+++ b/server/src/common/enums/game.status.enum.ts
@@ -20,3 +20,8 @@ export enum Difficulty {
   NORMAL = 'NORMAL',
   HARD = 'HARD',
 }
+
+export enum TerminationType {
+  SUCCESS = 'SUCCESS',
+  PLAYER_DISCONNECT = 'PLAYER_DISCONNECT',
+}

--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -12,7 +12,7 @@ import { UseFilters } from '@nestjs/common';
 import { WsExceptionFilter } from 'src/filters/ws-exception.filter';
 import { Player, Room, RoomSettings } from 'src/common/types/game.types';
 import { BadRequestException } from 'src/exceptions/game.exception';
-import { PlayerRole } from 'src/common/enums/game.status.enum';
+import { PlayerRole, TerminationType } from 'src/common/enums/game.status.enum';
 import { TimerService } from 'src/common/services/timer.service';
 import { TimerType } from 'src/common/enums/game.timer.enum';
 
@@ -102,7 +102,9 @@ export class GameGateway implements OnGatewayDisconnect {
   private async startNewRound(roomId: string) {
     const gameState = await this.gameService.setupRound(roomId);
     if (gameState.gameEnded) {
-      this.server.to(roomId).emit('gameEnded');
+      this.server.to(roomId).emit('gameEnded', {
+        terminationType: TerminationType.SUCCESS,
+      });
       return;
     }
 
@@ -214,7 +216,10 @@ export class GameGateway implements OnGatewayDisconnect {
               return;
             }
 
-            this.server.to(roomId).emit('playerLeft', {
+            await this.gameService.initializeGame(roomId);
+
+            this.server.to(roomId).emit('gameEnded', {
+              terminationType: TerminationType.PLAYER_DISCONNECT,
               leftPlayerId: playerId,
               hostId,
               players: remainingPlayers,

--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -211,10 +211,8 @@ export class GameGateway implements OnGatewayDisconnect {
 
           if (!isReconnected) {
             const { hostId, remainingPlayers } = await this.gameService.leaveRoom(roomId, playerId);
-            if (!remainingPlayers) {
-              this.timerService.stopGameTimer(roomId);
-              return;
-            }
+
+            this.timerService.stopGameTimer(roomId);
 
             await this.gameService.initializeGame(roomId);
 

--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -12,7 +12,7 @@ import { UseFilters } from '@nestjs/common';
 import { WsExceptionFilter } from 'src/filters/ws-exception.filter';
 import { Player, Room, RoomSettings } from 'src/common/types/game.types';
 import { BadRequestException } from 'src/exceptions/game.exception';
-import { PlayerRole, TerminationType } from 'src/common/enums/game.status.enum';
+import { PlayerRole, RoomStatus, TerminationType } from 'src/common/enums/game.status.enum';
 import { TimerService } from 'src/common/services/timer.service';
 import { TimerType } from 'src/common/enums/game.timer.enum';
 
@@ -210,9 +210,18 @@ export class GameGateway implements OnGatewayDisconnect {
           const isReconnected = sockets.some((socket) => socket.data.playerId === playerId);
 
           if (!isReconnected) {
-            const { hostId, remainingPlayers } = await this.gameService.leaveRoom(roomId, playerId);
+            const { roomStatus, hostId, remainingPlayers } = await this.gameService.leaveRoom(roomId, playerId);
 
             this.timerService.stopGameTimer(roomId);
+
+            if (roomStatus === RoomStatus.WAITING) {
+              this.server.to(roomId).emit('playerLeft', {
+                leftPlayerId: playerId,
+                hostId,
+                players: remainingPlayers,
+              });
+              return;
+            }
 
             await this.gameService.initializeGame(roomId);
 

--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -212,8 +212,6 @@ export class GameGateway implements OnGatewayDisconnect {
           if (!isReconnected) {
             const { roomStatus, hostId, remainingPlayers } = await this.gameService.leaveRoom(roomId, playerId);
 
-            this.timerService.stopGameTimer(roomId);
-
             if (roomStatus === RoomStatus.WAITING) {
               this.server.to(roomId).emit('playerLeft', {
                 leftPlayerId: playerId,
@@ -222,6 +220,8 @@ export class GameGateway implements OnGatewayDisconnect {
               });
               return;
             }
+
+            this.timerService.stopGameTimer(roomId);
 
             await this.gameService.initializeGame(roomId);
 

--- a/server/src/game/game.service.ts
+++ b/server/src/game/game.service.ts
@@ -167,7 +167,7 @@ export class GameService {
 
     await this.gameRepository.removePlayerFromRoom(roomId, playerId);
 
-    return { hostId, remainingPlayers };
+    return { roomStatus: room.status, hostId, remainingPlayers };
   }
 
   async initializeGame(roomId: string) {

--- a/server/src/game/game.service.ts
+++ b/server/src/game/game.service.ts
@@ -167,9 +167,21 @@ export class GameService {
 
     await this.gameRepository.removePlayerFromRoom(roomId, playerId);
 
-    // Todo: When someone leaves, move them to the waiting room
-
     return { hostId, remainingPlayers };
+  }
+
+  async initializeGame(roomId: string) {
+    await this.gameRepository.updateRoom(roomId, { status: RoomStatus.WAITING, currentRound: 0, currentWord: null });
+    const players = await this.gameRepository.getRoomPlayers(roomId);
+    await Promise.all(
+      players.map(({ playerId }) =>
+        this.gameRepository.updatePlayer(roomId, playerId, {
+          status: PlayerStatus.NOT_PLAYING,
+          role: null,
+          score: 0,
+        }),
+      ),
+    );
   }
 
   async updateSettings(roomId: string, playerId: string, data: Partial<RoomSettings>) {
@@ -223,16 +235,7 @@ export class GameService {
     if (!room) throw new RoomNotFoundException('Room not found');
 
     if (room.currentRound >= roomSettings.totalRounds) {
-      await this.gameRepository.updateRoom(roomId, { status: RoomStatus.WAITING, currentRound: 0, currentWord: null });
-      await Promise.all(
-        players.map(({ playerId }) =>
-          this.gameRepository.updatePlayer(roomId, playerId, {
-            status: PlayerStatus.NOT_PLAYING,
-            role: null,
-            score: 0,
-          }),
-        ),
-      );
+      await this.initializeGame(roomId);
       return { gameEnded: true };
     }
 


### PR DESCRIPTION
## 📂 작업 내용

closes #185 

- [x] 한 명이라도 나가면 게임 종료

## 💡 자세한 설명

- 플레이어가 재연결하지 않으면 leaveRoom 호출
- 방이 대기 상태(WAITING)일 경우, playerLeft 이벤트 전송
- 방이 게임 중일 경우, 
  - 플레이어가 방을 떠날 때 게임 타이머 중지
  - 게임 상태를 initializeGame으로 재초기화
  - 게임 종료 이벤트(gameEnded)를 방에 남아있는 플레이어들에게 전송

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
