### PR TITLE
feat: Change drawing of paint tool coordinates received from socket

### DIFF
--- a/client/src/components/canvas/GameCanvas.tsx
+++ b/client/src/components/canvas/GameCanvas.tsx
@@ -1,7 +1,7 @@
 import { MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent, useCallback, useEffect, useRef } from 'react';
 import { PlayerRole, RoomStatus } from '@troublepainter/core';
 import { Canvas } from '@/components/canvas/CanvasUI';
-import { COLORS_INFO, MAINCANVAS_RESOLUTION_WIDTH } from '@/constants/canvasConstants';
+import { COLORS_INFO, DEFAULT_MAX_PIXELS, MAINCANVAS_RESOLUTION_WIDTH } from '@/constants/canvasConstants';
 import { drawingSocketHandlers } from '@/handlers/socket/drawingSocket.handler';
 import { gameSocketHandlers } from '@/handlers/socket/gameSocket.handler';
 import { useDrawing } from '@/hooks/canvas/useDrawing';
@@ -48,7 +48,7 @@ interface GameCanvasProps {
  *
  * @category Components
  */
-const GameCanvas = ({ role, maxPixels = 10000, currentRound, roomStatus, isHidden }: GameCanvasProps) => {
+const GameCanvas = ({ role, maxPixels = DEFAULT_MAX_PIXELS, currentRound, roomStatus, isHidden }: GameCanvasProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { convertCoordinate } = useCoordinateScale(MAINCANVAS_RESOLUTION_WIDTH, canvasRef);
 

--- a/client/src/components/quiz/QuizStage.tsx
+++ b/client/src/components/quiz/QuizStage.tsx
@@ -3,6 +3,7 @@ import { PlayerRole } from '@troublepainter/core';
 import { GameCanvas } from '../canvas/GameCanvas';
 import { QuizTitle } from '../ui/QuizTitle';
 import sizzlingTimer from '@/assets/big-timer.gif';
+import { DEFAULT_MAX_PIXELS } from '@/constants/canvasConstants';
 import { useTimer } from '@/hooks/useTimer';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
 import { cn } from '@/utils/cn';
@@ -56,7 +57,7 @@ const QuizGameContent = () => {
         currentRound={room.currentRound}
         roomStatus={room.status}
         role={roundAssignedRole || PlayerRole.GUESSER}
-        maxPixels={100000}
+        maxPixels={DEFAULT_MAX_PIXELS}
         isHidden={shouldHideCanvas}
       />
 

--- a/client/src/constants/canvasConstants.ts
+++ b/client/src/constants/canvasConstants.ts
@@ -9,8 +9,8 @@ export const LINEWIDTH_VARIABLE = {
   STEP_WIDTH: 2,
 };
 
-export const MAINCANVAS_RESOLUTION_WIDTH = 1280;
-export const MAINCANVAS_RESOLUTION_HEIGHT = 800;
+export const MAINCANVAS_RESOLUTION_WIDTH = 1000;
+export const MAINCANVAS_RESOLUTION_HEIGHT = 625;
 //해상도 비율 변경 시 CanvasUI의 aspect-[16/10] 도 수정해야 정상적으로 렌더링됩니다.
 
 export const COLORS_INFO = [
@@ -21,4 +21,4 @@ export const COLORS_INFO = [
   { color: '회색', backgroundColor: '#808080' },
 ];
 
-export const DEFAULT_MAX_PIXELS = 1000; // 기본값 설정
+export const DEFAULT_MAX_PIXELS = 50000; // 기본값 설정

--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -106,7 +106,7 @@ export const useDrawing = (
 
       const strokeId = state.crdtRef.current.addStroke(drawingData);
       state.currentStrokeIdsRef.current.push(strokeId);
-      operation.drawStroke(drawingData);
+      if (state.drawingMode === DRAWING_MODE.PEN) operation.drawStroke(drawingData);
 
       return {
         type: CRDTMessageTypes.UPDATE,
@@ -280,7 +280,8 @@ export const useDrawing = (
           return;
         }
 
-        operation.drawStroke(stroke);
+        if (stroke.points.length > 2) operation.applyFill(stroke);
+        else operation.drawStroke(stroke);
 
         if (state.historyPointerRef.current < state.strokeHistoryRef.current.length - 1) {
           state.strokeHistoryRef.current = state.strokeHistoryRef.current.slice(0, state.historyPointerRef.current + 1);


### PR DESCRIPTION
## 📂 작업 내용

closes #181 

- [x] 경로 그리기 방식에서 픽셀 그리기 방식으로 변경
- [x] 잔여 픽셀량 이상의 경로는 칠하지 못하도록 수정
- [x] 화요일 낮에 시연 후 적용 여부 결정

## 💡 자세한 설명

- 최대 픽셀 상수로 제어하도록 수정 (현재 5만개)
- 소켓에서 받아온 좌표 배열 그려주는 applyFill 메소드 생성
- 좌표 배열이 펜 툴 좌표인지, 페인트 툴 좌표인지 구분하는 로직 반영 (좌표 배열 3개 이상이면 applyFill, 미만이면 drawStroke 실행)
- 그림판 해상도 수정 (1280x800 -> 1000x625, 비율은 16:10 유지) 

## 📗 참고 자료 & 구현 결과 (선택)
![fill](https://github.com/user-attachments/assets/4f475872-5043-47e3-a778-85b89d6335f1)


## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [X] PR 제목을 형식에 맞게 작성했나요?
- [X] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [X] 이슈는 close 했나요?
- [X] Reviewers, Labels를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [X] 불필요한 코드는 제거했나요?
