### PR TITLE
fix: Adjust merge logic to rely on CRDT timestamps

### DIFF
--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -99,10 +99,14 @@ export const useDrawing = (
 
   const renderStroke = useCallback(
     (strokeData: DrawingData, position: 'middle' | 'end') => {
-      if (position === 'middle' || strokeData.points.length > 2) {
+      if (position === 'middle') {
         operation.redrawCanvas();
       } else {
-        operation.drawStroke(strokeData);
+        if (strokeData.points.length > 2) {
+          operation.applyFill(strokeData);
+        } else {
+          operation.drawStroke(strokeData);
+        }
       }
     },
     [operation],

--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -116,8 +116,7 @@ export const useDrawing = (
     (point: Point): CRDTUpdateMessage | null => {
       if (state.checkInkAvailability() === false || !state.crdtRef.current) return null;
 
-      state.currentStrokeIdsRef.current = [];
-      currentDrawingPoints.current = [point];
+      currentDrawingPoints.current = state.drawingMode === DRAWING_MODE.PEN ? [point] : [];
 
       const drawingData =
         state.drawingMode === DRAWING_MODE.FILL
@@ -175,22 +174,28 @@ export const useDrawing = (
   );
 
   const stopDrawing = useCallback(() => {
-    if (!state.crdtRef.current || !currentDrawingPoints.current || state.currentStrokeIdsRef.current.length === 0)
-      return;
+    if (!state.crdtRef.current || state.currentStrokeIdsRef.current.length === 0) return;
 
     if (state.historyPointerRef.current < state.strokeHistoryRef.current.length - 1) {
       state.strokeHistoryRef.current = state.strokeHistoryRef.current.slice(0, state.historyPointerRef.current + 1);
     }
 
-    const allPoints: Point[] = [];
-    state.currentStrokeIdsRef.current.forEach((strokeId) => {
-      const stroke = state.crdtRef.current!.strokes.find((s) => s.id === strokeId);
-      if (stroke) {
-        allPoints.push(...stroke.stroke.points);
-      }
-    });
+    let drawingData: DrawingData;
 
-    const drawingData = createDrawingData(allPoints);
+    if (state.drawingMode === DRAWING_MODE.FILL) {
+      const stroke = state.crdtRef.current.strokes.find((s) => s.id === state.currentStrokeIdsRef.current[0])?.stroke;
+      if (!stroke) return;
+      drawingData = stroke;
+    } else {
+      const allPoints: Point[] = [];
+      state.currentStrokeIdsRef.current.forEach((strokeId) => {
+        const stroke = state.crdtRef.current!.strokes.find((s) => s.id === strokeId);
+        if (stroke) {
+          allPoints.push(...stroke.stroke.points);
+        }
+      });
+      drawingData = createDrawingData(allPoints);
+    }
 
     state.strokeHistoryRef.current.push({
       strokeIds: [...state.currentStrokeIdsRef.current],

--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -6,6 +6,7 @@ import {
   CRDTUpdateMessage,
   CRDTSyncMessage,
   RoomStatus,
+  DrawingData,
 } from '@troublepainter/core';
 import { useDrawingOperation } from './useDrawingOperation';
 import { useDrawingState } from './useDrawingState';
@@ -87,6 +88,26 @@ export const useDrawing = (
   const operation = useDrawingOperation(canvasRef, state);
   const currentDrawingPoints = useRef<Point[]>([]);
 
+  const createDrawingData = useCallback(
+    (points: Point[]): DrawingData => ({
+      points,
+      style: operation.getCurrentStyle(),
+      timestamp: Date.now(),
+    }),
+    [operation],
+  );
+
+  const renderStroke = useCallback(
+    (strokeData: DrawingData, position: 'middle' | 'end') => {
+      if (position === 'middle' || strokeData.points.length > 2) {
+        operation.redrawCanvas();
+      } else {
+        operation.drawStroke(strokeData);
+      }
+    },
+    [operation],
+  );
+
   const startDrawing = useCallback(
     (point: Point): CRDTUpdateMessage | null => {
       if (state.checkInkAvailability() === false || !state.crdtRef.current) return null;
@@ -97,31 +118,28 @@ export const useDrawing = (
       const drawingData =
         state.drawingMode === DRAWING_MODE.FILL
           ? operation.floodFill(Math.floor(point.x), Math.floor(point.y))
-          : {
-              points: [point],
-              style: operation.getCurrentStyle(),
-            };
+          : createDrawingData([point]);
 
       if (!drawingData) return null;
 
-      const strokeId = state.crdtRef.current.addStroke(drawingData);
-      state.currentStrokeIdsRef.current.push(strokeId);
-      if (state.drawingMode === DRAWING_MODE.PEN) operation.drawStroke(drawingData);
+      const { id, position } = state.crdtRef.current.addStroke(drawingData);
+      state.currentStrokeIdsRef.current.push(id);
+      renderStroke(drawingData, position);
 
       return {
         type: CRDTMessageTypes.UPDATE,
         state: {
-          key: strokeId,
-          register: state.crdtRef.current.state[strokeId],
+          key: id,
+          register: state.crdtRef.current.state[id],
         },
       };
     },
-    [state, operation],
+    [state, operation, createDrawingData, renderStroke],
   );
 
   const continueDrawing = useCallback(
     (point: Point): CRDTUpdateMessage | null => {
-      if (!state.crdtRef.current || currentDrawingPoints.current.length === 0 || state.inkRemaining <= 0) return null;
+      if (!state.crdtRef.current || currentDrawingPoints.current.length === 0) return null;
       if (state.drawingMode === DRAWING_MODE.FILL) return null;
 
       const lastPoint = currentDrawingPoints.current[currentDrawingPoints.current.length - 1];
@@ -133,27 +151,23 @@ export const useDrawing = (
       state.setInkRemaining((prev: number) => Math.max(0, prev - pixelsUsed));
 
       currentDrawingPoints.current.push(point);
+      const drawingData = createDrawingData([...currentDrawingPoints.current]);
 
-      const drawingData = {
-        points: [...currentDrawingPoints.current],
-        style: operation.getCurrentStyle(),
-      };
-
-      const strokeId = state.crdtRef.current.addStroke(drawingData);
-      state.currentStrokeIdsRef.current.push(strokeId);
-      operation.drawStroke(drawingData);
+      const { id, position } = state.crdtRef.current.addStroke(drawingData);
+      state.currentStrokeIdsRef.current.push(id);
+      renderStroke(drawingData, position);
 
       currentDrawingPoints.current = [point];
 
       return {
         type: CRDTMessageTypes.UPDATE,
         state: {
-          key: strokeId,
-          register: state.crdtRef.current.state[strokeId],
+          key: id,
+          register: state.crdtRef.current.state[id],
         },
       };
     },
-    [state, operation],
+    [state, createDrawingData, renderStroke],
   );
 
   const stopDrawing = useCallback(() => {
@@ -172,23 +186,20 @@ export const useDrawing = (
       }
     });
 
-    const drawingData = {
-      points: allPoints,
-      style: operation.getCurrentStyle(),
-    };
+    const drawingData = createDrawingData(allPoints);
 
     state.strokeHistoryRef.current.push({
       strokeIds: [...state.currentStrokeIdsRef.current],
       isLocal: true,
       drawingData,
+      timestamp: drawingData.timestamp,
     });
 
     state.historyPointerRef.current = state.strokeHistoryRef.current.length - 1;
-
     currentDrawingPoints.current = [];
     state.currentStrokeIdsRef.current = [];
     state.updateHistoryState();
-  }, [state]);
+  }, [state, createDrawingData]);
 
   const undo = useCallback((): CRDTUpdateMessage[] | null => {
     if (!state.crdtRef.current || state.historyPointerRef.current < 0) return null;
@@ -235,17 +246,16 @@ export const useDrawing = (
 
     if (!nextEntry?.isLocal || !nextEntry.drawingData) return null;
 
-    const strokeId = state.crdtRef.current.addStroke(nextEntry.drawingData);
+    const { id } = state.crdtRef.current.addStroke(nextEntry.drawingData);
+    nextEntry.strokeIds = [id];
 
     const update: CRDTUpdateMessage = {
       type: CRDTMessageTypes.UPDATE,
       state: {
-        key: strokeId,
-        register: state.crdtRef.current.state[strokeId],
+        key: id,
+        register: state.crdtRef.current.state[id],
       },
     };
-
-    nextEntry.strokeIds = [strokeId];
 
     state.historyPointerRef.current++;
     state.updateHistoryState();
@@ -259,8 +269,10 @@ export const useDrawing = (
       if (!state.crdtRef.current) return;
 
       if (crdtDrawingData.type === CRDTMessageTypes.SYNC) {
-        state.crdtRef.current.merge(crdtDrawingData.state);
-        operation.redrawCanvas();
+        const { requiresRedraw } = state.crdtRef.current.merge(crdtDrawingData.state);
+        if (requiresRedraw) {
+          operation.redrawCanvas();
+        }
 
         if (roomStatus === 'DRAWING') {
           state.strokeHistoryRef.current = [];
@@ -272,7 +284,10 @@ export const useDrawing = (
         const peerId = key.split('-')[0];
         const isLocalUpdate = peerId === state.currentPlayerId;
 
-        if (!state.crdtRef.current.mergeRegister(key, register) || isLocalUpdate) return;
+        if (isLocalUpdate) return;
+
+        const { updated, position } = state.crdtRef.current.mergeRegister(key, register);
+        if (!updated) return;
 
         const stroke = register[2];
         if (!stroke) {
@@ -280,8 +295,7 @@ export const useDrawing = (
           return;
         }
 
-        if (stroke.points.length > 2) operation.applyFill(stroke);
-        else operation.drawStroke(stroke);
+        renderStroke(stroke, position);
 
         if (state.historyPointerRef.current < state.strokeHistoryRef.current.length - 1) {
           state.strokeHistoryRef.current = state.strokeHistoryRef.current.slice(0, state.historyPointerRef.current + 1);
@@ -291,12 +305,14 @@ export const useDrawing = (
           strokeIds: [key],
           isLocal: false,
           drawingData: stroke,
+          timestamp: stroke.timestamp,
         });
+
         state.historyPointerRef.current++;
         state.updateHistoryState();
       }
     },
-    [state.currentPlayerId, operation, roomStatus],
+    [state.currentPlayerId, operation, roomStatus, renderStroke], // renderStroke 의존성 추가
   );
 
   const getAllDrawingData = useCallback((): CRDTSyncMessage | null => {

--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -143,7 +143,7 @@ export const useDrawing = (
 
   const continueDrawing = useCallback(
     (point: Point): CRDTUpdateMessage | null => {
-      if (!state.crdtRef.current || currentDrawingPoints.current.length === 0) return null;
+      if (!state.crdtRef.current || currentDrawingPoints.current.length === 0 || state.inkRemaining <= 0) return null;
       if (state.drawingMode === DRAWING_MODE.FILL) return null;
 
       const lastPoint = currentDrawingPoints.current[currentDrawingPoints.current.length - 1];
@@ -316,7 +316,7 @@ export const useDrawing = (
         state.updateHistoryState();
       }
     },
-    [state.currentPlayerId, operation, roomStatus, renderStroke], // renderStroke 의존성 추가
+    [state.currentPlayerId, operation, roomStatus, renderStroke],
   );
 
   const getAllDrawingData = useCallback((): CRDTSyncMessage | null => {

--- a/client/src/hooks/canvas/useDrawingOperation.ts
+++ b/client/src/hooks/canvas/useDrawingOperation.ts
@@ -174,6 +174,7 @@ export const useDrawingOperation = (
       return {
         points: filledPoints,
         style: getCurrentStyle(),
+        timestamp: Date.now(),
       };
     },
     [currentColor, inkRemaining, getCurrentStyle, setInkRemaining],

--- a/client/src/types/canvas.types.ts
+++ b/client/src/types/canvas.types.ts
@@ -33,6 +33,7 @@ export interface StrokeHistoryEntry {
   strokeIds: string[];
   isLocal: boolean;
   drawingData: DrawingData;
+  timestamp: number;
 }
 
 export interface DrawingOptions {

--- a/core/crdt/LWWMap.ts
+++ b/core/crdt/LWWMap.ts
@@ -1,16 +1,30 @@
-import { MapState, RegisterState, DrawingData } from '@/types/crdt.types';
+import { DrawingData, MapState, RegisterState } from '@/types/crdt.types';
 import { LWWRegister } from './LWWRegister';
 
 export class LWWMap {
   readonly id: string;
   #data: Map<string, LWWRegister<DrawingData | null>>;
+  #sortedStrokes: Array<{ id: string; stroke: DrawingData }>;
 
   constructor(id: string, initialState: MapState = {}) {
     this.id = id;
     this.#data = new Map();
+    this.#sortedStrokes = [];
 
-    for (const [key, registerState] of Object.entries(initialState)) {
-      this.#data.set(key, new LWWRegister(this.id, registerState));
+    const entries = Object.entries(initialState)
+      .map(([key, state]) => ({
+        key,
+        register: new LWWRegister(this.id, state),
+        timestamp: state[1],
+      }))
+      .sort((a, b) => b.timestamp - a.timestamp);
+
+    for (const entry of entries) {
+      this.#data.set(entry.key, entry.register);
+      const value = entry.register.value;
+      if (value !== null) {
+        this.#sortedStrokes.push({ id: entry.key, stroke: value });
+      }
     }
   }
 
@@ -22,69 +36,105 @@ export class LWWMap {
     return state;
   }
 
-  get strokes(): { id: string; stroke: DrawingData }[] {
-    const result = [];
-    for (const [key, register] of this.#data.entries()) {
-      const value = register.value;
-      if (value !== null) {
-        result.push({ id: key, stroke: value });
+  get strokes(): Array<{ id: string; stroke: DrawingData }> {
+    return this.#sortedStrokes;
+  }
+
+  // 정렬된 배열에 새로운 스트로크를 삽입할 인덱스 찾기
+  private findSortedInsertIndex(newStroke: DrawingData): number {
+    for (let i = this.#sortedStrokes.length - 1; i >= 0; i--) {
+      const item = this.#sortedStrokes[i];
+      if (item.stroke.timestamp <= newStroke.timestamp) {
+        return i + 1;
       }
     }
-    return result;
+    return 0;
   }
 
-  // 선 생성
-  addStroke(stroke: DrawingData): string {
-    const timestamp = Date.now();
-    const id = `${this.id}-${timestamp}-${Math.random().toString(36).substring(2, 9)}`;
-    const register = new LWWRegister<DrawingData | null>(this.id, [this.id, timestamp, stroke]);
+  // 정렬된 배열에 새로운 스트로크 삽입
+  private insertSortedStroke(id: string, stroke: DrawingData): 'end' | 'middle' {
+    const index = this.findSortedInsertIndex(stroke);
+
+    if (index === this.#sortedStrokes.length) {
+      this.#sortedStrokes.push({ id, stroke });
+      return 'end';
+    }
+
+    this.#sortedStrokes.splice(index, 0, { id, stroke });
+    return 'middle';
+  }
+
+  // 새로운 스트로크 추가
+  addStroke(stroke: DrawingData): { id: string; position: 'end' | 'middle' } {
+    const id = `${this.id}-${stroke.timestamp}-${Math.random().toString(36).substring(2, 9)}`;
+    const register = new LWWRegister<DrawingData | null>(this.id, [this.id, stroke.timestamp, stroke]);
+
     this.#data.set(id, register);
-    return id;
+    const position = this.insertSortedStroke(id, stroke);
+
+    return { id, position };
   }
 
-  // 선 삭제
+  // 스트로크 삭제
   deleteStroke(id: string): boolean {
     const register = this.#data.get(id);
     if (register) {
       register.set(null);
+      const index = this.#sortedStrokes.findIndex((item) => item.id === id);
+      if (index !== -1) {
+        this.#sortedStrokes.splice(index, 1);
+      }
       return true;
     }
     return false;
   }
 
-  // 원격 상태 병합
-  merge(remoteState: MapState): string[] {
+  // 전체 상태 병합
+  merge(remoteState: MapState): { updatedKeys: string[]; requiresRedraw: boolean } {
     const updatedKeys: string[] = [];
+    let requiresRedraw = false;
 
     for (const [key, remoteRegisterState] of Object.entries(remoteState)) {
-      const localRegister = this.#data.get(key);
-
-      if (localRegister) {
-        // 기존 레지스터가 있으면 병합
-        if (localRegister.merge(remoteRegisterState)) {
-          updatedKeys.push(key);
-        }
-      } else {
-        // 새로운 레지스터면 추가
-        this.#data.set(key, new LWWRegister(this.id, remoteRegisterState));
+      const result = this.mergeRegister(key, remoteRegisterState);
+      if (result.updated) {
         updatedKeys.push(key);
+        if (result.position === 'middle') {
+          requiresRedraw = true;
+        }
       }
     }
 
-    return updatedKeys;
+    return { updatedKeys, requiresRedraw };
   }
 
-  // 단일 레지스터 업데이트
-  mergeRegister(key: string, remoteRegisterState: RegisterState<DrawingData | null>): boolean {
+  // 단일 레지스터 병합
+  mergeRegister(
+    key: string,
+    remoteRegisterState: RegisterState<DrawingData | null>,
+  ): { updated: boolean; position: 'end' | 'middle' } {
     const localRegister = this.#data.get(key);
+    const [, , remoteValue] = remoteRegisterState;
+    let position: 'end' | 'middle' = 'end';
 
     if (localRegister) {
-      // 기존 stroke에 대한 원격 업데이트 병합
-      return localRegister.merge(remoteRegisterState);
+      const wasUpdated = localRegister.merge(remoteRegisterState);
+      if (wasUpdated) {
+        const index = this.#sortedStrokes.findIndex((item) => item.id === key);
+        if (index !== -1) {
+          this.#sortedStrokes.splice(index, 1);
+        }
+        if (remoteValue !== null) {
+          position = this.insertSortedStroke(key, remoteValue);
+        }
+        return { updated: true, position };
+      }
+      return { updated: false, position };
     } else {
-      // 새로운 stroke 추가
       this.#data.set(key, new LWWRegister(this.id, remoteRegisterState));
-      return true;
+      if (remoteValue !== null) {
+        position = this.insertSortedStroke(key, remoteValue);
+      }
+      return { updated: true, position };
     }
   }
 }

--- a/core/types/crdt.types.ts
+++ b/core/types/crdt.types.ts
@@ -11,6 +11,7 @@ export interface StrokeStyle {
 export interface DrawingData {
   points: Point[];
   style: StrokeStyle;
+  timestamp: number;
 }
 
 export type RegisterState<T> = [peerId: string, timestamp: number, value: T];


### PR DESCRIPTION
## 📂 작업 내용

closes #188 

- [x] 작업 내용

## 💡 자세한 설명

### 1. 동기화 로직 수정
* LWWMap 클래스에 **`#sortedStrokes`** 배열 추가: 시간순으로 정렬된 스트로크들 관리
* **`findSortedInsertIndex`**: 정렬된 배열에 새로운 스트로크를 삽입할 인덱스 찾는 함수
* **`insertSortedStroke`**:  정렬된 배열에 새로운 스트로크 삽입 및 해당 결과 반환 (`middle` or `end`)
* `insertSortedStroke` 가 반환한 스트로크 삽입 위치 `middle` / `end`에 따라 드로잉 로직 변경됨

### 2. 드로잉 로직 수정
* 스트로크 삽입 위치가 `middle`인 경우: **redraw 수행**
  * B가 그림 그림 ➡️ A(나)가 방금 그림 그림 ➡️ B의 스트로크 정보 소켓으로 수신 받음 ➡️ 
    내가 방금 그린 그림보다 더 먼저 그려진 그림이므로 `middle` 위치에 삽입 되어야 하고, 방금 그린 그림보다 아래에 깔려야함
* 스트로크 삽입 위치가 `end`인 경우: 
  * `strokeData.points.length`가 2보다 큰 경우는 `FILL` 모드인 경우임 ➡️ **채우기 operation 수행**
  * `strokeData.points.length`가 2와 같거나 작은 경우는 `PEN` 모드인 경우임 ➡️ **스트로크 그리기 operation 수행**

```ts
const renderStroke = useCallback(
    (strokeData: DrawingData, position: 'middle' | 'end') => {
      if (position === 'middle') {
        operation.redrawCanvas();
      } else {
        if (strokeData.points.length > 2) {
          operation.applyFill(strokeData);
        } else {
          operation.drawStroke(strokeData);
        }
      }
    },
    [operation],
  );
```

### 3. 보조 함수 추가
* `createDrawingData`: style, timestamp 속성 추가해주는 함수
* `renderStroke`: 스트로크 렌더링 로직 중앙화 (`redrawCanvas` / `applyFill` / `drawStroke`)

## 📗 참고 자료 & 구현 결과 (선택)

### timestamp 기반 병합 로직 반영 `전`

* 왼쪽 브라우저 창 + 아이패드에서 동시에 같은 영역 FILL 클릭 시 ➡️ 병합 제대로 되지 않아 다른 화면 보임

<video src="https://github.com/user-attachments/assets/72427151-1a10-40e0-8aca-a1c9d3e8cc73"></video>

### timestamp 기반 병합 로직 반영 `후`

* 왼쪽 브라우저 창 + 아이패드에서 동시에 같은 영역 FILL 클릭 시 ➡️ 병합되어 동일한 캔버스 화면 보임

<video src="https://github.com/user-attachments/assets/6002d57c-11ea-4ea2-906f-3615e0c851df"></video>

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
