### PR TITLE
fix: Update undo/redo logic to align with CRDT changes

### DIFF
--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -12,73 +12,6 @@ import { useDrawingOperation } from './useDrawingOperation';
 import { useDrawingState } from './useDrawingState';
 import { DRAWING_MODE } from '@/constants/canvasConstants';
 
-/**
- * 캔버스 드로잉 기능을 관리하는 Hook입니다.
- *
- * @remarks
- * 캔버스의 실제 드로잉 작업을 처리합니다.
- * - 펜/채우기 모드 드로잉
- * - 실행 취소/다시 실행
- * - 잉크 잔량 관리
- * - 실시간 드로잉 데이터 동기화 및 기록
- *
- * 드로잉은 mousedown부터 mouseup까지를 하나의 단위로 처리하며,
- * 실시간으로는 각 stroke 단위로 동기화하고 히스토리는 mouseup 단위로 기록됩니다.
- *
- * @param canvasRef - 캔버스 엘리먼트의 RefObject
- * @param options - 드로잉 설정 옵션
- * @param options.maxPixels - 최대 사용 가능한 픽셀 수
- *
- * @example
- * ```tsx
- * const GameCanvas = ({ role, maxPixels = 100000 }: GameCanvasProps) => {
- *   const canvasRef = useRef<HTMLCanvasElement>(null);
- *
- *   const {
- *     currentColor,
- *     brushSize,
- *     drawingMode,
- *     inkRemaining,
- *     startDrawing,
- *     continueDrawing,
- *     stopDrawing,
- *   } = useDrawing(canvasRef, { maxPixels });
- *
- *   const handleDrawStart = useCallback((e: ReactMouseEvent | ReactTouchEvent) => {
- *     const point = getDrawPoint(e, canvasRef.current);
- *     startDrawing(point);
- *   }, [startDrawing]);
- *
- *   return (
- *     <Canvas
- *       canvasRef={canvasRef}
- *       isDrawable={true}
- *       brushSize={brushSize}
- *       inkRemaining={inkRemaining}
- *     />
- *   );
- * };
- * ```
- *
- * @returns 드로잉 관련 상태와 메소드들을 포함하는 객체
- * @property currentColor - 현재 선택된 색상
- * @property setCurrentColor - 현재 색상을 변경하는 함수
- * @property brushSize - 현재 브러시 크기
- * @property setBrushSize - 브러시 크기를 변경하는 함수
- * @property drawingMode - 현재 드로잉 모드 (펜/채우기)
- * @property setDrawingMode - 드로잉 모드를 변경하는 함수
- * @property inkRemaining - 남은 잉크량
- * @property canUndo - 실행 취소 가능 여부
- * @property canRedo - 다시 실행 가능 여부
- * @property startDrawing - 드로잉 시작 함수 (mousedown)
- * @property continueDrawing - 드로잉 진행 함수 (mousemove)
- * @property stopDrawing - 드로잉 종료 함수 (mouseup)
- * @property applyDrawing - 외부 드로잉 데이터 적용 함수
- * @property undo - 마지막 드로잉 작업을 실행 취소하는 함수
- * @property redo - 마지막으로 실행 취소된 작업을 다시 실행하는 함수
- *
- * @category Hooks
- */
 export const useDrawing = (
   canvasRef: RefObject<HTMLCanvasElement>,
   roomStatus: RoomStatus,
@@ -94,21 +27,6 @@ export const useDrawing = (
       style: operation.getCurrentStyle(),
       timestamp: Date.now(),
     }),
-    [operation],
-  );
-
-  const renderStroke = useCallback(
-    (strokeData: DrawingData, position: 'middle' | 'end') => {
-      if (position === 'middle') {
-        operation.redrawCanvas();
-      } else {
-        if (strokeData.points.length > 2) {
-          operation.applyFill(strokeData);
-        } else {
-          operation.drawStroke(strokeData);
-        }
-      }
-    },
     [operation],
   );
 
@@ -128,7 +46,16 @@ export const useDrawing = (
 
       const { id, position } = state.crdtRef.current.addStroke(drawingData);
       state.currentStrokeIdsRef.current.push(id);
-      renderStroke(drawingData, position);
+
+      if (position === 'middle') {
+        operation.redrawCanvas();
+      } else {
+        if (drawingData.points.length > 2) {
+          operation.applyFill(drawingData);
+        } else {
+          operation.drawStroke(drawingData);
+        }
+      }
 
       return {
         type: CRDTMessageTypes.UPDATE,
@@ -138,7 +65,7 @@ export const useDrawing = (
         },
       };
     },
-    [state, operation, createDrawingData, renderStroke],
+    [state, operation, createDrawingData],
   );
 
   const continueDrawing = useCallback(
@@ -159,7 +86,12 @@ export const useDrawing = (
 
       const { id, position } = state.crdtRef.current.addStroke(drawingData);
       state.currentStrokeIdsRef.current.push(id);
-      renderStroke(drawingData, position);
+
+      if (position === 'middle') {
+        operation.redrawCanvas();
+      } else {
+        operation.drawStroke(drawingData);
+      }
 
       currentDrawingPoints.current = [point];
 
@@ -171,7 +103,7 @@ export const useDrawing = (
         },
       };
     },
-    [state, createDrawingData, renderStroke],
+    [state, createDrawingData],
   );
 
   const stopDrawing = useCallback(() => {
@@ -181,101 +113,84 @@ export const useDrawing = (
       state.strokeHistoryRef.current = state.strokeHistoryRef.current.slice(0, state.historyPointerRef.current + 1);
     }
 
-    let drawingData: DrawingData;
+    const firstStroke = state.crdtRef.current.strokes.find((s) => s.id === state.currentStrokeIdsRef.current[0]);
+    if (!firstStroke) return;
 
-    if (state.drawingMode === DRAWING_MODE.FILL) {
-      const stroke = state.crdtRef.current.strokes.find((s) => s.id === state.currentStrokeIdsRef.current[0])?.stroke;
-      if (!stroke) return;
-      drawingData = stroke;
-    } else {
-      const allPoints: Point[] = [];
-      state.currentStrokeIdsRef.current.forEach((strokeId) => {
-        const stroke = state.crdtRef.current!.strokes.find((s) => s.id === strokeId);
-        if (stroke) {
-          allPoints.push(...stroke.stroke.points);
-        }
-      });
-      drawingData = createDrawingData(allPoints);
-    }
-
-    // 새 작업 추가
     state.strokeHistoryRef.current.push({
       strokeIds: [...state.currentStrokeIdsRef.current],
       isLocal: true,
-      drawingData,
-      timestamp: drawingData.timestamp,
+      drawingData: firstStroke.stroke,
+      timestamp: firstStroke.stroke.timestamp,
     });
 
     state.historyPointerRef.current = state.strokeHistoryRef.current.length - 1;
     currentDrawingPoints.current = [];
     state.currentStrokeIdsRef.current = [];
     state.updateHistoryState();
-  }, [state, createDrawingData]);
+  }, [state]);
 
   const undo = useCallback((): CRDTUpdateMessage[] | null => {
     if (!state.crdtRef.current || state.historyPointerRef.current < 0) return null;
 
-    let currentIndex = state.historyPointerRef.current;
-    let currentEntry = state.strokeHistoryRef.current[currentIndex];
-
-    while (currentIndex >= 0) {
-      if (currentEntry?.isLocal) {
-        const updates = currentEntry.strokeIds.map((strokeId): CRDTUpdateMessage => {
-          state.crdtRef.current!.deleteStroke(strokeId);
-          return {
-            type: CRDTMessageTypes.UPDATE,
-            state: {
-              key: strokeId,
-              register: state.crdtRef.current!.state[strokeId],
-            },
-          };
-        });
-
-        state.historyPointerRef.current = currentIndex - 1;
-        state.updateHistoryState();
-        operation.redrawCanvas();
-
-        return updates;
-      }
-      currentIndex--;
-      currentEntry = state.strokeHistoryRef.current[currentIndex];
+    let currentEntry = state.strokeHistoryRef.current[state.historyPointerRef.current];
+    while (currentEntry && !currentEntry.isLocal && state.historyPointerRef.current > 0) {
+      state.historyPointerRef.current--;
+      currentEntry = state.strokeHistoryRef.current[state.historyPointerRef.current];
     }
 
-    return null;
+    if (!currentEntry?.isLocal) return null;
+
+    const updates = currentEntry.strokeIds.map((strokeId): CRDTUpdateMessage => {
+      state.crdtRef.current!.deactivateStroke(strokeId);
+      return {
+        type: CRDTMessageTypes.UPDATE,
+        state: {
+          key: strokeId,
+          register: state.crdtRef.current!.state[strokeId],
+        },
+      };
+    });
+
+    state.historyPointerRef.current--;
+    state.updateHistoryState();
+    operation.redrawCanvas();
+
+    return updates;
   }, [state, operation]);
 
   const redo = useCallback((): CRDTUpdateMessage[] | null => {
     if (!state.crdtRef.current || state.historyPointerRef.current >= state.strokeHistoryRef.current.length - 1)
       return null;
 
-    let nextIndex = state.historyPointerRef.current + 1;
-    let nextEntry = state.strokeHistoryRef.current[nextIndex];
-
-    while (nextIndex < state.strokeHistoryRef.current.length) {
-      if (nextEntry?.isLocal && nextEntry.drawingData) {
-        const { id } = state.crdtRef.current.addStroke(nextEntry.drawingData);
-        nextEntry.strokeIds = [id];
-
-        const update: CRDTUpdateMessage = {
-          type: CRDTMessageTypes.UPDATE,
-          state: {
-            key: id,
-            register: state.crdtRef.current.state[id],
-          },
-        };
-
-        state.historyPointerRef.current = nextIndex;
-        state.updateHistoryState();
-        operation.redrawCanvas();
-        renderStroke(nextEntry.drawingData, 'end');
-
-        return [update];
-      }
-      nextIndex++;
-      nextEntry = state.strokeHistoryRef.current[nextIndex];
+    let nextEntry = state.strokeHistoryRef.current[state.historyPointerRef.current + 1];
+    while (
+      nextEntry &&
+      !nextEntry.isLocal &&
+      state.historyPointerRef.current < state.strokeHistoryRef.current.length - 1
+    ) {
+      state.historyPointerRef.current++;
+      nextEntry = state.strokeHistoryRef.current[state.historyPointerRef.current + 1];
     }
 
-    return null;
+    if (!nextEntry?.isLocal) return null;
+
+    // 해당 스트로크들을 활성화
+    const updates = nextEntry.strokeIds.map((strokeId): CRDTUpdateMessage => {
+      state.crdtRef.current!.activateStroke(strokeId);
+      return {
+        type: CRDTMessageTypes.UPDATE,
+        state: {
+          key: strokeId,
+          register: state.crdtRef.current!.state[strokeId],
+        },
+      };
+    });
+
+    state.historyPointerRef.current++;
+    state.updateHistoryState();
+    operation.redrawCanvas();
+
+    return updates;
   }, [state, operation]);
 
   const applyDrawing = useCallback(
@@ -309,7 +224,15 @@ export const useDrawing = (
           return;
         }
 
-        renderStroke(stroke, position);
+        if (position === 'middle') {
+          operation.redrawCanvas();
+        } else {
+          if (stroke.points.length > 2) {
+            operation.applyFill(stroke);
+          } else {
+            operation.drawStroke(stroke);
+          }
+        }
 
         state.strokeHistoryRef.current.push({
           strokeIds: [key],
@@ -322,7 +245,7 @@ export const useDrawing = (
         state.updateHistoryState();
       }
     },
-    [state.currentPlayerId, operation, roomStatus, renderStroke],
+    [state.currentPlayerId, operation, roomStatus],
   );
 
   const getAllDrawingData = useCallback((): CRDTSyncMessage | null => {
@@ -335,8 +258,8 @@ export const useDrawing = (
   }, [state.crdtRef]);
 
   const resetCanvas = useCallback(() => {
-    state.resetDrawingState(); // 상태 초기화
-    operation.clearCanvas(); // 캔버스 초기화
+    state.resetDrawingState();
+    operation.clearCanvas();
   }, [state.resetDrawingState, operation.clearCanvas]);
 
   return {

--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -30,6 +30,21 @@ export const useDrawing = (
     [operation],
   );
 
+  const renderStroke = useCallback(
+    (strokeData: DrawingData, position: 'middle' | 'end') => {
+      if (position === 'middle') {
+        operation.redrawCanvas();
+      } else {
+        if (strokeData.points.length > 2) {
+          operation.applyFill(strokeData);
+        } else {
+          operation.drawStroke(strokeData);
+        }
+      }
+    },
+    [operation],
+  );
+
   const startDrawing = useCallback(
     (point: Point): CRDTUpdateMessage | null => {
       if (state.checkInkAvailability() === false || !state.crdtRef.current) return null;
@@ -46,16 +61,7 @@ export const useDrawing = (
 
       const { id, position } = state.crdtRef.current.addStroke(drawingData);
       state.currentStrokeIdsRef.current.push(id);
-
-      if (position === 'middle') {
-        operation.redrawCanvas();
-      } else {
-        if (drawingData.points.length > 2) {
-          operation.applyFill(drawingData);
-        } else {
-          operation.drawStroke(drawingData);
-        }
-      }
+      renderStroke(drawingData, position);
 
       return {
         type: CRDTMessageTypes.UPDATE,
@@ -65,7 +71,7 @@ export const useDrawing = (
         },
       };
     },
-    [state, operation, createDrawingData],
+    [state, operation, createDrawingData, renderStroke],
   );
 
   const continueDrawing = useCallback(
@@ -86,12 +92,7 @@ export const useDrawing = (
 
       const { id, position } = state.crdtRef.current.addStroke(drawingData);
       state.currentStrokeIdsRef.current.push(id);
-
-      if (position === 'middle') {
-        operation.redrawCanvas();
-      } else {
-        operation.drawStroke(drawingData);
-      }
+      renderStroke(drawingData, position);
 
       currentDrawingPoints.current = [point];
 
@@ -103,7 +104,7 @@ export const useDrawing = (
         },
       };
     },
-    [state, createDrawingData],
+    [state, createDrawingData, renderStroke],
   );
 
   const stopDrawing = useCallback(() => {
@@ -172,9 +173,8 @@ export const useDrawing = (
       nextEntry = state.strokeHistoryRef.current[state.historyPointerRef.current + 1];
     }
 
-    if (!nextEntry?.isLocal) return null;
+    if (!nextEntry?.isLocal || !nextEntry.drawingData) return null;
 
-    // 해당 스트로크들을 활성화
     const updates = nextEntry.strokeIds.map((strokeId): CRDTUpdateMessage => {
       state.crdtRef.current!.activateStroke(strokeId);
       return {
@@ -219,8 +219,10 @@ export const useDrawing = (
         if (!updated) return;
 
         const stroke = register[2];
-        if (!stroke) {
-          operation.redrawCanvas();
+
+        // null인 경우는 undo된 상태
+        if (stroke === null) {
+          operation.redrawCanvas(); // 전체 다시 그리기
           return;
         }
 
@@ -238,10 +240,10 @@ export const useDrawing = (
           strokeIds: [key],
           isLocal: false,
           drawingData: stroke,
-          timestamp: stroke.timestamp,
+          timestamp: stroke.timestamp || Date.now(),
         });
 
-        state.historyPointerRef.current++;
+        // 원격 작업은 히스토리 포인터에 영향을 주지 않음
         state.updateHistoryState();
       }
     },

--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -12,6 +12,73 @@ import { useDrawingOperation } from './useDrawingOperation';
 import { useDrawingState } from './useDrawingState';
 import { DRAWING_MODE } from '@/constants/canvasConstants';
 
+/**
+ * 캔버스 드로잉 기능을 관리하는 Hook입니다.
+ *
+ * @remarks
+ * 캔버스의 실제 드로잉 작업을 처리합니다.
+ * - 펜/채우기 모드 드로잉
+ * - 실행 취소/다시 실행
+ * - 잉크 잔량 관리
+ * - 실시간 드로잉 데이터 동기화 및 기록
+ *
+ * 드로잉은 mousedown부터 mouseup까지를 하나의 단위로 처리하며,
+ * 실시간으로는 각 stroke 단위로 동기화하고 히스토리는 mouseup 단위로 기록됩니다.
+ *
+ * @param canvasRef - 캔버스 엘리먼트의 RefObject
+ * @param options - 드로잉 설정 옵션
+ * @param options.maxPixels - 최대 사용 가능한 픽셀 수
+ *
+ * @example
+ * ```tsx
+ * const GameCanvas = ({ role, maxPixels = 100000 }: GameCanvasProps) => {
+ *   const canvasRef = useRef<HTMLCanvasElement>(null);
+ *
+ *   const {
+ *     currentColor,
+ *     brushSize,
+ *     drawingMode,
+ *     inkRemaining,
+ *     startDrawing,
+ *     continueDrawing,
+ *     stopDrawing,
+ *   } = useDrawing(canvasRef, { maxPixels });
+ *
+ *   const handleDrawStart = useCallback((e: ReactMouseEvent | ReactTouchEvent) => {
+ *     const point = getDrawPoint(e, canvasRef.current);
+ *     startDrawing(point);
+ *   }, [startDrawing]);
+ *
+ *   return (
+ *     <Canvas
+ *       canvasRef={canvasRef}
+ *       isDrawable={true}
+ *       brushSize={brushSize}
+ *       inkRemaining={inkRemaining}
+ *     />
+ *   );
+ * };
+ * ```
+ *
+ * @returns 드로잉 관련 상태와 메소드들을 포함하는 객체
+ * @property currentColor - 현재 선택된 색상
+ * @property setCurrentColor - 현재 색상을 변경하는 함수
+ * @property brushSize - 현재 브러시 크기
+ * @property setBrushSize - 브러시 크기를 변경하는 함수
+ * @property drawingMode - 현재 드로잉 모드 (펜/채우기)
+ * @property setDrawingMode - 드로잉 모드를 변경하는 함수
+ * @property inkRemaining - 남은 잉크량
+ * @property canUndo - 실행 취소 가능 여부
+ * @property canRedo - 다시 실행 가능 여부
+ * @property startDrawing - 드로잉 시작 함수 (mousedown)
+ * @property continueDrawing - 드로잉 진행 함수 (mousemove)
+ * @property stopDrawing - 드로잉 종료 함수 (mouseup)
+ * @property applyDrawing - 외부 드로잉 데이터 적용 함수
+ * @property undo - 마지막 드로잉 작업을 실행 취소하는 함수
+ * @property redo - 마지막으로 실행 취소된 작업을 다시 실행하는 함수
+ *
+ * @category Hooks
+ */
 export const useDrawing = (
   canvasRef: RefObject<HTMLCanvasElement>,
   roomStatus: RoomStatus,
@@ -265,8 +332,8 @@ export const useDrawing = (
   }, [state.crdtRef]);
 
   const resetCanvas = useCallback(() => {
-    state.resetDrawingState();
-    operation.clearCanvas();
+    state.resetDrawingState(); // 상태 초기화
+    operation.clearCanvas(); // 캔버스 초기화
   }, [state.resetDrawingState, operation.clearCanvas]);
 
   return {

--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -116,6 +116,7 @@ export const useDrawing = (
     (point: Point): CRDTUpdateMessage | null => {
       if (state.checkInkAvailability() === false || !state.crdtRef.current) return null;
 
+      state.currentStrokeIdsRef.current = [];
       currentDrawingPoints.current = state.drawingMode === DRAWING_MODE.PEN ? [point] : [];
 
       const drawingData =
@@ -197,6 +198,7 @@ export const useDrawing = (
       drawingData = createDrawingData(allPoints);
     }
 
+    // 새 작업 추가
     state.strokeHistoryRef.current.push({
       strokeIds: [...state.currentStrokeIdsRef.current],
       isLocal: true,
@@ -213,64 +215,67 @@ export const useDrawing = (
   const undo = useCallback((): CRDTUpdateMessage[] | null => {
     if (!state.crdtRef.current || state.historyPointerRef.current < 0) return null;
 
-    let currentEntry = state.strokeHistoryRef.current[state.historyPointerRef.current];
-    while (currentEntry && !currentEntry.isLocal && state.historyPointerRef.current > 0) {
-      state.historyPointerRef.current--;
-      currentEntry = state.strokeHistoryRef.current[state.historyPointerRef.current];
+    let currentIndex = state.historyPointerRef.current;
+    let currentEntry = state.strokeHistoryRef.current[currentIndex];
+
+    while (currentIndex >= 0) {
+      if (currentEntry?.isLocal) {
+        const updates = currentEntry.strokeIds.map((strokeId): CRDTUpdateMessage => {
+          state.crdtRef.current!.deleteStroke(strokeId);
+          return {
+            type: CRDTMessageTypes.UPDATE,
+            state: {
+              key: strokeId,
+              register: state.crdtRef.current!.state[strokeId],
+            },
+          };
+        });
+
+        state.historyPointerRef.current = currentIndex - 1;
+        state.updateHistoryState();
+        operation.redrawCanvas();
+
+        return updates;
+      }
+      currentIndex--;
+      currentEntry = state.strokeHistoryRef.current[currentIndex];
     }
 
-    if (!currentEntry?.isLocal) return null;
-
-    const updates = currentEntry.strokeIds.map((strokeId): CRDTUpdateMessage => {
-      state.crdtRef.current!.deleteStroke(strokeId);
-      return {
-        type: CRDTMessageTypes.UPDATE,
-        state: {
-          key: strokeId,
-          register: state.crdtRef.current!.state[strokeId],
-        },
-      };
-    });
-
-    state.historyPointerRef.current--;
-    state.updateHistoryState();
-    operation.redrawCanvas();
-
-    return updates;
+    return null;
   }, [state, operation]);
 
   const redo = useCallback((): CRDTUpdateMessage[] | null => {
     if (!state.crdtRef.current || state.historyPointerRef.current >= state.strokeHistoryRef.current.length - 1)
       return null;
 
-    let nextEntry = state.strokeHistoryRef.current[state.historyPointerRef.current + 1];
-    while (
-      nextEntry &&
-      !nextEntry.isLocal &&
-      state.historyPointerRef.current < state.strokeHistoryRef.current.length - 1
-    ) {
-      state.historyPointerRef.current++;
-      nextEntry = state.strokeHistoryRef.current[state.historyPointerRef.current + 1];
+    let nextIndex = state.historyPointerRef.current + 1;
+    let nextEntry = state.strokeHistoryRef.current[nextIndex];
+
+    while (nextIndex < state.strokeHistoryRef.current.length) {
+      if (nextEntry?.isLocal && nextEntry.drawingData) {
+        const { id } = state.crdtRef.current.addStroke(nextEntry.drawingData);
+        nextEntry.strokeIds = [id];
+
+        const update: CRDTUpdateMessage = {
+          type: CRDTMessageTypes.UPDATE,
+          state: {
+            key: id,
+            register: state.crdtRef.current.state[id],
+          },
+        };
+
+        state.historyPointerRef.current = nextIndex;
+        state.updateHistoryState();
+        operation.redrawCanvas();
+        renderStroke(nextEntry.drawingData, 'end');
+
+        return [update];
+      }
+      nextIndex++;
+      nextEntry = state.strokeHistoryRef.current[nextIndex];
     }
 
-    if (!nextEntry?.isLocal || !nextEntry.drawingData) return null;
-
-    const { id } = state.crdtRef.current.addStroke(nextEntry.drawingData);
-    nextEntry.strokeIds = [id];
-
-    const update: CRDTUpdateMessage = {
-      type: CRDTMessageTypes.UPDATE,
-      state: {
-        key: id,
-        register: state.crdtRef.current.state[id],
-      },
-    };
-
-    state.historyPointerRef.current++;
-    state.updateHistoryState();
-    operation.redrawCanvas();
-
-    return [update];
+    return null;
   }, [state, operation]);
 
   const applyDrawing = useCallback(
@@ -305,10 +310,6 @@ export const useDrawing = (
         }
 
         renderStroke(stroke, position);
-
-        if (state.historyPointerRef.current < state.strokeHistoryRef.current.length - 1) {
-          state.strokeHistoryRef.current = state.strokeHistoryRef.current.slice(0, state.historyPointerRef.current + 1);
-        }
 
         state.strokeHistoryRef.current.push({
           strokeIds: [key],

--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -147,7 +147,7 @@ export const useDrawing = (
         type: CRDTMessageTypes.UPDATE,
         state: {
           key: strokeId,
-          register: state.crdtRef.current!.state[strokeId],
+          register: state.crdtRef.current!.state[strokeId], // 변경된 상태 가져오기
         },
       };
     });
@@ -220,12 +220,25 @@ export const useDrawing = (
 
         const stroke = register[2];
 
-        // null인 경우는 undo된 상태
-        if (stroke === null) {
-          operation.redrawCanvas(); // 전체 다시 그리기
+        if (!stroke) {
+          operation.redrawCanvas();
           return;
         }
 
+        // 새로운 스트로크 또는 redo된 스트로크
+        const existingEntryIndex = state.strokeHistoryRef.current.findIndex((entry) => entry.strokeIds.includes(key));
+
+        if (existingEntryIndex === -1) {
+          // 새로운 스트로크인 경우만 히스토리에 추가
+          state.strokeHistoryRef.current.push({
+            strokeIds: [key],
+            isLocal: false,
+            drawingData: stroke,
+            timestamp: stroke.timestamp || Date.now(),
+          });
+        }
+
+        // 그리기 작업
         if (position === 'middle') {
           operation.redrawCanvas();
         } else {
@@ -236,14 +249,6 @@ export const useDrawing = (
           }
         }
 
-        state.strokeHistoryRef.current.push({
-          strokeIds: [key],
-          isLocal: false,
-          drawingData: stroke,
-          timestamp: stroke.timestamp || Date.now(),
-        });
-
-        // 원격 작업은 히스토리 포인터에 영향을 주지 않음
         state.updateHistoryState();
       }
     },

--- a/client/src/hooks/canvas/useDrawing.ts
+++ b/client/src/hooks/canvas/useDrawing.ts
@@ -7,6 +7,7 @@ import {
   CRDTSyncMessage,
   RoomStatus,
   DrawingData,
+  RegisterState,
 } from '@troublepainter/core';
 import { useDrawingOperation } from './useDrawingOperation';
 import { useDrawingState } from './useDrawingState';
@@ -210,11 +211,19 @@ export const useDrawing = (
 
     const updates = currentEntry.strokeIds.map((strokeId): CRDTUpdateMessage => {
       state.crdtRef.current!.deactivateStroke(strokeId);
+      const baseRegister = state.crdtRef.current!.state[strokeId];
+      const register: RegisterState<DrawingData | null> = {
+        peerId: baseRegister.peerId,
+        timestamp: baseRegister.timestamp,
+        value: baseRegister.value,
+        isDeactivated: true,
+      };
+
       return {
         type: CRDTMessageTypes.UPDATE,
         state: {
           key: strokeId,
-          register: state.crdtRef.current!.state[strokeId], // 변경된 상태 가져오기
+          register,
         },
       };
     });
@@ -244,11 +253,19 @@ export const useDrawing = (
 
     const updates = nextEntry.strokeIds.map((strokeId): CRDTUpdateMessage => {
       state.crdtRef.current!.activateStroke(strokeId);
+      const baseRegister = state.crdtRef.current!.state[strokeId];
+      const register: RegisterState<DrawingData | null> = {
+        peerId: baseRegister.peerId,
+        timestamp: baseRegister.timestamp,
+        value: baseRegister.value,
+        isDeactivated: false,
+      };
+
       return {
         type: CRDTMessageTypes.UPDATE,
         state: {
           key: strokeId,
-          register: state.crdtRef.current!.state[strokeId],
+          register,
         },
       };
     });
@@ -282,41 +299,35 @@ export const useDrawing = (
 
         if (isLocalUpdate) return;
 
+        // CRDT 상태 업데이트
         const { updated, position } = state.crdtRef.current.mergeRegister(key, register);
         if (!updated) return;
 
-        const stroke = register[2];
+        const stroke = register.value;
+        const isDeactivated = register.isDeactivated ?? false;
 
-        if (!stroke) {
-          operation.redrawCanvas();
-          return;
-        }
-
-        // 새로운 스트로크 또는 redo된 스트로크
+        // 새로운 스트로크이고 비활성화되지 않은 경우만 히스토리에 추가
         const existingEntryIndex = state.strokeHistoryRef.current.findIndex((entry) => entry.strokeIds.includes(key));
 
-        if (existingEntryIndex === -1) {
-          // 새로운 스트로크인 경우만 히스토리에 추가
+        if (existingEntryIndex === -1 && stroke && !isDeactivated) {
           state.strokeHistoryRef.current.push({
             strokeIds: [key],
             isLocal: false,
             drawingData: stroke,
             timestamp: stroke.timestamp || Date.now(),
           });
+          state.updateHistoryState();
         }
 
-        // 그리기 작업
-        if (position === 'middle') {
+        if (position === 'middle' || existingEntryIndex !== -1 || isDeactivated) {
           operation.redrawCanvas();
-        } else {
+        } else if (stroke) {
           if (stroke.points.length > 2) {
             operation.applyFill(stroke);
           } else {
             operation.drawStroke(stroke);
           }
         }
-
-        state.updateHistoryState();
       }
     },
     [state.currentPlayerId, operation, roomStatus],

--- a/client/src/hooks/canvas/useDrawingOperation.ts
+++ b/client/src/hooks/canvas/useDrawingOperation.ts
@@ -103,12 +103,13 @@ export const useDrawingOperation = (
     const { canvas, ctx } = getCanvasContext(canvasRef);
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-    state.crdtRef.current.strokes
-      .filter((stroke) => stroke.stroke !== null)
-      .forEach(({ stroke }) => {
-        if (stroke.points.length > 2) applyFill(stroke);
-        else drawStroke(stroke);
-      });
+    state.crdtRef.current.strokes.forEach(({ stroke }) => {
+      if (stroke.points.length > 2) {
+        applyFill(stroke);
+      } else {
+        drawStroke(stroke);
+      }
+    });
   }, [drawStroke]);
 
   const applyFill = (drawingData: DrawingData) => {

--- a/client/src/hooks/canvas/useDrawingOperation.ts
+++ b/client/src/hooks/canvas/useDrawingOperation.ts
@@ -103,13 +103,14 @@ export const useDrawingOperation = (
     const { canvas, ctx } = getCanvasContext(canvasRef);
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-    state.crdtRef.current.strokes.forEach(({ stroke }) => {
+    const activeStrokes = state.crdtRef.current.getActiveStrokes();
+    for (const { stroke } of activeStrokes) {
       if (stroke.points.length > 2) {
         applyFill(stroke);
       } else {
         drawStroke(stroke);
       }
-    });
+    }
   }, [drawStroke]);
 
   const applyFill = (drawingData: DrawingData) => {

--- a/client/src/hooks/canvas/useDrawingState.ts
+++ b/client/src/hooks/canvas/useDrawingState.ts
@@ -95,12 +95,10 @@ export const useDrawingState = (options?: { maxPixels?: number }) => {
 
   const updateHistoryState = useCallback(() => {
     const localHistory = strokeHistoryRef.current.filter((entry) => entry.isLocal);
-    const localItemsCount = strokeHistoryRef.current
-      .slice(0, historyPointerRef.current + 1)
-      .filter((entry) => entry.isLocal).length;
+    const currentLocalIndex = localHistory.findIndex((_, index) => index === historyPointerRef.current);
 
-    setCanUndo(localItemsCount > 0);
-    setCanRedo(localItemsCount < localHistory.length);
+    setCanUndo(currentLocalIndex >= 0);
+    setCanRedo(currentLocalIndex < localHistory.length - 1);
   }, []);
 
   const checkInkAvailability = useCallback(() => {

--- a/client/src/types/canvas.types.ts
+++ b/client/src/types/canvas.types.ts
@@ -34,6 +34,7 @@ export interface StrokeHistoryEntry {
   isLocal: boolean;
   drawingData: DrawingData;
   timestamp: number;
+  isDeactivated?: boolean;
 }
 
 export interface DrawingOptions {

--- a/client/src/types/canvas.types.ts
+++ b/client/src/types/canvas.types.ts
@@ -34,7 +34,6 @@ export interface StrokeHistoryEntry {
   isLocal: boolean;
   drawingData: DrawingData;
   timestamp: number;
-  isDeactivated?: boolean;
 }
 
 export interface DrawingOptions {

--- a/core/crdt/LWWMap.ts
+++ b/core/crdt/LWWMap.ts
@@ -89,6 +89,32 @@ export class LWWMap {
     return false;
   }
 
+  deactivateStroke(id: string): boolean {
+    const register = this.#data.get(id);
+    if (register) {
+      register.setDeactivated(true);
+      const index = this.#sortedStrokes.findIndex((item) => item.id === id);
+      if (index !== -1) {
+        this.#sortedStrokes.splice(index, 1);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  activateStroke(id: string): boolean {
+    const register = this.#data.get(id);
+    if (register && register.isDeactivated) {
+      register.setDeactivated(false);
+      const stroke = register.value;
+      if (stroke !== null) {
+        const position = this.insertSortedStroke(id, stroke);
+        return position === 'end';
+      }
+    }
+    return false;
+  }
+
   // 전체 상태 병합
   merge(remoteState: MapState): { updatedKeys: string[]; requiresRedraw: boolean } {
     const updatedKeys: string[] = [];

--- a/core/crdt/LWWMap.ts
+++ b/core/crdt/LWWMap.ts
@@ -15,14 +15,14 @@ export class LWWMap {
       .map(([key, state]) => ({
         key,
         register: new LWWRegister(this.id, state),
-        timestamp: state[1],
+        timestamp: state.timestamp,
       }))
       .sort((a, b) => b.timestamp - a.timestamp);
 
     for (const entry of entries) {
       this.#data.set(entry.key, entry.register);
       const value = entry.register.value;
-      if (value !== null) {
+      if (value !== null && !entry.register.isDeactivated) {
         this.#sortedStrokes.push({ id: entry.key, stroke: value });
       }
     }
@@ -64,10 +64,14 @@ export class LWWMap {
     return 'middle';
   }
 
-  // 새로운 스트로크 추가
   addStroke(stroke: DrawingData): { id: string; position: 'end' | 'middle' } {
     const id = `${this.id}-${stroke.timestamp}-${Math.random().toString(36).substring(2, 9)}`;
-    const register = new LWWRegister<DrawingData | null>(this.id, [this.id, stroke.timestamp, stroke]);
+    const register = new LWWRegister<DrawingData | null>(this.id, {
+      peerId: this.id,
+      timestamp: stroke.timestamp,
+      value: stroke,
+      isDeactivated: false,
+    });
 
     this.#data.set(id, register);
     const position = this.insertSortedStroke(id, stroke);
@@ -139,28 +143,57 @@ export class LWWMap {
     remoteRegisterState: RegisterState<DrawingData | null>,
   ): { updated: boolean; position: 'end' | 'middle' } {
     const localRegister = this.#data.get(key);
-    const [, , remoteValue] = remoteRegisterState;
     let position: 'end' | 'middle' = 'end';
 
     if (localRegister) {
+      if (
+        remoteRegisterState.isDeactivated !== undefined &&
+        remoteRegisterState.isDeactivated !== localRegister.isDeactivated
+      ) {
+        const wasDeactivated = localRegister.isDeactivated;
+        localRegister.setDeactivated(remoteRegisterState.isDeactivated);
+
+        const index = this.#sortedStrokes.findIndex((item) => item.id === key);
+        if (remoteRegisterState.isDeactivated) {
+          if (index !== -1) {
+            this.#sortedStrokes.splice(index, 1);
+          }
+        } else if (remoteRegisterState.value !== null) {
+          if (index === -1) {
+            position = this.insertSortedStroke(key, remoteRegisterState.value);
+          }
+        }
+
+        return { updated: true, position };
+      }
+
       const wasUpdated = localRegister.merge(remoteRegisterState);
-      if (wasUpdated) {
+      if (wasUpdated && !localRegister.isDeactivated) {
         const index = this.#sortedStrokes.findIndex((item) => item.id === key);
         if (index !== -1) {
           this.#sortedStrokes.splice(index, 1);
         }
-        if (remoteValue !== null) {
-          position = this.insertSortedStroke(key, remoteValue);
+        if (remoteRegisterState.value !== null) {
+          position = this.insertSortedStroke(key, remoteRegisterState.value);
         }
         return { updated: true, position };
       }
       return { updated: false, position };
     } else {
-      this.#data.set(key, new LWWRegister(this.id, remoteRegisterState));
-      if (remoteValue !== null) {
-        position = this.insertSortedStroke(key, remoteValue);
+      const newRegister = new LWWRegister(this.id, remoteRegisterState);
+      this.#data.set(key, newRegister);
+
+      if (remoteRegisterState.value !== null && !remoteRegisterState.isDeactivated) {
+        position = this.insertSortedStroke(key, remoteRegisterState.value);
       }
       return { updated: true, position };
     }
+  }
+
+  getActiveStrokes(): Array<{ id: string; stroke: DrawingData }> {
+    return this.#sortedStrokes.filter(({ id }) => {
+      const register = this.#data.get(id);
+      return register && !register.isDeactivated;
+    });
   }
 }

--- a/core/crdt/LWWRegister.ts
+++ b/core/crdt/LWWRegister.ts
@@ -3,10 +3,12 @@ import { RegisterState } from '@/types/crdt.types';
 export class LWWRegister<T> {
   readonly id: string;
   #state: RegisterState<T>; // [peerId, timestamp, value]
+  #isDeactivated: boolean;
 
   constructor(id: string, initialState: RegisterState<T>) {
     this.id = id;
     this.#state = initialState;
+    this.#isDeactivated = false;
   }
 
   get value(): T {
@@ -17,11 +19,18 @@ export class LWWRegister<T> {
     return this.#state;
   }
 
+  get isDeactivated(): boolean {
+    return this.#isDeactivated;
+  }
+
   set(value: T): void {
     this.#state = [this.id, Date.now(), value];
   }
 
-  // 원격 상태와 병합 (더 새로운 타임스탬프 또는 더 큰 피어 ID 우선)
+  setDeactivated(value: boolean): void {
+    this.#isDeactivated = value;
+  }
+
   merge(remoteState: RegisterState<T>): boolean {
     const [remotePeer, remoteTimestamp] = remoteState;
     const [localPeer, localTimestamp] = this.#state;

--- a/core/crdt/LWWRegister.ts
+++ b/core/crdt/LWWRegister.ts
@@ -2,17 +2,15 @@ import { RegisterState } from '@/types/crdt.types';
 
 export class LWWRegister<T> {
   readonly id: string;
-  #state: RegisterState<T>; // [peerId, timestamp, value]
-  #isDeactivated: boolean;
+  #state: RegisterState<T>;
 
   constructor(id: string, initialState: RegisterState<T>) {
     this.id = id;
     this.#state = initialState;
-    this.#isDeactivated = false;
   }
 
   get value(): T {
-    return this.#state[2];
+    return this.#state.value;
   }
 
   get state(): RegisterState<T> {
@@ -20,22 +18,38 @@ export class LWWRegister<T> {
   }
 
   get isDeactivated(): boolean {
-    return this.#isDeactivated;
+    return this.#state.isDeactivated ?? false;
   }
 
   set(value: T): void {
-    this.#state = [this.id, Date.now(), value];
+    this.#state = {
+      peerId: this.id,
+      timestamp: Date.now(),
+      value,
+      isDeactivated: this.#state.isDeactivated,
+    };
   }
 
   setDeactivated(value: boolean): void {
-    this.#isDeactivated = value;
+    this.#state = {
+      ...this.#state,
+      isDeactivated: value,
+    };
   }
 
   merge(remoteState: RegisterState<T>): boolean {
-    const [remotePeer, remoteTimestamp] = remoteState;
-    const [localPeer, localTimestamp] = this.#state;
+    if (remoteState.isDeactivated !== this.#state.isDeactivated) {
+      this.#state = {
+        ...this.#state,
+        isDeactivated: remoteState.isDeactivated,
+      };
+      return true;
+    }
 
-    if (remoteTimestamp > localTimestamp || (remoteTimestamp === localTimestamp && remotePeer > localPeer)) {
+    if (
+      remoteState.timestamp > this.#state.timestamp ||
+      (remoteState.timestamp === this.#state.timestamp && remoteState.peerId > this.#state.peerId)
+    ) {
       this.#state = remoteState;
       return true;
     }

--- a/core/types/crdt.types.ts
+++ b/core/types/crdt.types.ts
@@ -14,7 +14,12 @@ export interface DrawingData {
   timestamp: number;
 }
 
-export type RegisterState<T> = [peerId: string, timestamp: number, value: T];
+export type RegisterState<T> = {
+  peerId: string;
+  timestamp: number;
+  value: T;
+  isDeactivated?: boolean;
+};
 
 export type MapState = {
   [key: string]: RegisterState<DrawingData | null>;
@@ -35,6 +40,7 @@ export type CRDTUpdateMessage = {
   state: {
     key: string;
     register: RegisterState<DrawingData | null>;
+    isDeactivated?: boolean;
   };
 };
 


### PR DESCRIPTION
## 📂 작업 내용

closes #192 

- [x] CRDT 로직 변경에 따라 undo/redo 로직 수정

## 💡 자세한 설명

### 1. RegisterState 구조 변경
* 기존에는 `RegisterState`가 배열 형태([peerId, timestamp, value])로 구현되어 있었습니다.
* undo/redo 시 스트로크의 활성 상태를 관리하기 위해 별도의 `isDeactivated` 플래그를 추가했습니다.

```ts
export type RegisterState<T> = {
  peerId: string;
  timestamp: number;
  value: T;
  isDeactivated?: boolean;
};
```

### 2. LWWMap의 상태 관리 변경

* 기존에는 스트로크를 undo할 때 value를 null로 설정하는 방식을 사용했으나, 이제는 `isDeactivated` 플래그를 통해 스트로크의 활성 상태를 명시적으로 관리합니다.
* 스트로크의 value는 그대로 유지하면서 isDeactivated 상태만 토글하여 undo/redo를 처리하도록 변경했습니다.

### 3. 캔버스 Redraw 변경

* `getActiveStrokes` 메서드를 추가하여 활성화된 스트로크만 필터링하여 반환하도록 구현했습니다.
* 캔버스 `redraw` 시 비활성화된 스트로크는 자동으로 제외됩니다.
* `mergeRegister`에서 스트로크의 활성 상태가 변경될 때만 `sortedStrokes` 배열을 업데이트하도록 했습니다.

## 📗 참고 자료 & 구현 결과 (선택)

<video src="https://github.com/user-attachments/assets/6d2ec0e9-f963-4b5d-b2d3-00d684637b93"></video>

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
