### PR TITLE
fix: Add retry logic for fetching words in startGame

### DIFF
--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -27,7 +27,6 @@ export class GameGateway implements OnGatewayDisconnect {
 
   private disconnectTimeouts: Map<string, NodeJS.Timeout> = new Map();
   private readonly DISCONNECT_TIMEOUT = 10000;
-  private finalDrawing: any;
 
   constructor(
     private readonly gameService: GameService,


### PR DESCRIPTION
## 📂 작업 내용

closes #196 

- [x] 단어 안 나오는 문제 해결

## 💡 자세한 설명

- 단어 가져오기 실패 시, 최대 10번까지 재시도 후 기본 단어 사용하도록 수정
- 단어 가져오는 로직을 fetchWords 메서드로 분리

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
