### PR TITLE
refactor: Modify unit tests for CRDT LWW

### DIFF
--- a/core/vitest.config.ts
+++ b/core/vitest.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
   test: {
     globals: true,
     include: ['**/test/*.test.ts'],
     environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
   },
 });


### PR DESCRIPTION
## 📂 작업 내용

closes #197 

- [x] CRDT 로직 변경에 따른 유닛 테스트 코드 수정

## 💡 자세한 설명

* CRDT 로직 변경으로 인해 유닛 코드도 그에 맞춰 수정했습니다.
* 변경된 로직은 아래 PR 참고 부탁드립니다!
- https://github.com/boostcampwm-2024/web30-stop-troublepainter/pull/190
 - https://github.com/boostcampwm-2024/web30-stop-troublepainter/pull/193

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
