### PR TITLE
feat: Implement game logic and UI 

### DIFF
--- a/client/src/components/modal/RoundEndModal.tsx
+++ b/client/src/components/modal/RoundEndModal.tsx
@@ -8,6 +8,7 @@ import gameWin from '@/assets/sounds/game-win.mp3';
 import { Modal } from '@/components/ui/Modal';
 import { useModal } from '@/hooks/useModal';
 import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
+import { useTimerStore } from '@/stores/timer.store';
 import { cn } from '@/utils/cn';
 import { SOUND_IDS, SoundManager } from '@/utils/soundManager';
 
@@ -16,6 +17,7 @@ const RoundEndModal = () => {
   const roundWinners = useGameSocketStore((state) => state.roundWinners);
   const players = useGameSocketStore((state) => state.players);
   const currentPlayerId = useGameSocketStore((state) => state.currentPlayerId);
+  const timer = useTimerStore((state) => state.timers.ENDING);
 
   const { isModalOpened, openModal, closeModal } = useModal();
   const [showAnimation, setShowAnimation] = useState(false);
@@ -100,7 +102,10 @@ const RoundEndModal = () => {
         isModalOpened={isModalOpened}
         className="max-w-[26.875rem] sm:max-w-[61.75rem]"
       >
-        <div className="flex min-h-[12rem] items-center justify-center sm:min-h-[15.75rem]">
+        <div className="relative flex min-h-[12rem] items-center justify-center sm:min-h-[15.75rem]">
+          <span className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-full border-2 border-violet-300 text-base text-violet-300">
+            {timer}
+          </span>
           <p className="text-center text-2xl sm:m-2 sm:text-3xl">
             {isDevilWin ? (
               <> 정답을 맞춘 구경꾼이 없습니다</>

--- a/client/src/components/quiz/QuizStage.tsx
+++ b/client/src/components/quiz/QuizStage.tsx
@@ -52,7 +52,7 @@ const QuizStageContainer = () => {
       return roundAssignedRole !== PlayerRole.GUESSER ? `${room.currentWord}` : '';
     }
     if (room.status === RoomStatus.GUESSING) {
-      return roundAssignedRole !== PlayerRole.GUESSER ? `${room.currentWord} (맞추는중...)` : '맞춰보세요-!';
+      return roundAssignedRole !== PlayerRole.GUESSER ? `${room.currentWord} (맞히는중...)` : '맞혀보세요-!';
     }
   }, [room.status, room.currentWord, roundAssignedRole]);
 

--- a/client/src/components/quiz/QuizStage.tsx
+++ b/client/src/components/quiz/QuizStage.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { PlayerRole } from '@troublepainter/core';
+import { PlayerRole, RoomStatus } from '@troublepainter/core';
 import { GameCanvas } from '../canvas/GameCanvas';
 import { QuizTitle } from '../ui/QuizTitle';
 import sizzlingTimer from '@/assets/big-timer.gif';
@@ -46,20 +46,35 @@ const QuizStageContainer = () => {
         return 0;
     }
   }, [room?.status, timers, roomSettings?.drawTime]);
+
+  const quizTitleText = useMemo(() => {
+    if (room.status === RoomStatus.DRAWING) {
+      return roundAssignedRole !== PlayerRole.GUESSER ? `${room.currentWord}` : '';
+    }
+    if (room.status === RoomStatus.GUESSING) {
+      return roundAssignedRole !== PlayerRole.GUESSER ? `${room.currentWord} (맞추는중...)` : '맞춰보세요-!';
+    }
+  }, [room.status, room.currentWord, roundAssignedRole]);
+
   return (
     <>
       {/* 구경꾼 전용 타이머 */}
-      <div className={cn('relative', shouldHideSizzlingTimer && 'hidden')}>
-        <img src={sizzlingTimer} alt="구경꾼 전용 타이머" width={450} />
-        <span className="absolute left-[42%] top-[45%] text-6xl text-stroke-md lg:text-7xl">
-          {timers.DRAWING ?? roomSettings.drawTime - 5}
-        </span>
+      <div className={cn(shouldHideSizzlingTimer && 'hidden')}>
+        <p className="mb-3 text-center text-xl text-eastbay-50 text-stroke-md sm:mb-0 sm:text-2xl lg:text-3xl">
+          화가들이 실력을 뽐내는중...
+        </p>
+        <div className="relative">
+          <img src={sizzlingTimer} alt="구경꾼 전용 타이머" width={450} />
+          <span className="absolute left-[42%] top-[45%] text-6xl text-stroke-md lg:text-7xl">
+            {timers.DRAWING ?? roomSettings.drawTime - 5}
+          </span>
+        </div>
       </div>
 
       <QuizTitle
         currentRound={room.currentRound}
         totalRound={roomSettings.totalRounds}
-        title={room?.currentWord || (roundAssignedRole === PlayerRole.GUESSER ? '맞춰보세용-!' : '')}
+        title={quizTitleText || '제시어가 없습니다.'}
         remainingTime={remainingTime || 0}
         isHidden={shouldHideQuizTitle}
       />

--- a/client/src/components/setting/Setting.tsx
+++ b/client/src/components/setting/Setting.tsx
@@ -16,7 +16,7 @@ export interface RoomSettingItem {
 }
 
 export const ROOM_SETTINGS: RoomSettingItem[] = [
-  { label: '라운드 수', key: 'totalRounds', options: [3, 5], shortcutKey: 'DROPDOWN_TOTAL_ROUNDS' },
+  { label: '라운드 수', key: 'totalRounds', options: [3, 5, 7, 9, 11], shortcutKey: 'DROPDOWN_TOTAL_ROUNDS' },
   { label: '최대 플레이어 수', key: 'maxPlayers', options: [4, 5], shortcutKey: 'DROPDOWN_MAX_PLAYERS' },
   { label: '제한 시간', key: 'drawTime', options: [15, 20, 25, 30], shortcutKey: 'DROPDOWN_DRAW_TIME' },
   //{ label: '픽셀 수', key: 'maxPixels', options: [300, 500] },
@@ -41,21 +41,20 @@ const Setting = memo(({ className, ...props }: HTMLAttributes<HTMLDivElement>) =
     setSelectedValues(roomSettings);
   }, [roomSettings]);
 
-  useEffect(() => {
-    if (!isHost || !selectedValues || !selectedValues.drawTime) return;
-    // 방장일 때만 실행되는 설정 업데이트
-    void gameSocketHandlers.updateSettings({
-      settings: { ...selectedValues, drawTime: selectedValues.drawTime + 5 },
-    });
-    actions.updateRoomSettings(selectedValues);
-  }, [selectedValues, isHost]);
-
-  const handleSettingChange = useCallback((key: keyof RoomSettings, value: string) => {
-    setSelectedValues((prev) => ({
-      ...prev,
-      [key]: Number(value),
-    }));
-  }, []);
+  const handleSettingChange = useCallback(
+    (key: keyof RoomSettings, value: string) => {
+      const newSettings = {
+        ...selectedValues,
+        [key]: Number(value),
+      };
+      setSelectedValues(newSettings);
+      void gameSocketHandlers.updateSettings({
+        settings: { ...newSettings, drawTime: newSettings.drawTime + 5 },
+      });
+      actions.updateRoomSettings(newSettings);
+    },
+    [selectedValues, actions],
+  );
 
   return (
     <section

--- a/client/src/layouts/GameLayout.tsx
+++ b/client/src/layouts/GameLayout.tsx
@@ -30,7 +30,7 @@ const GameLayout = () => {
       <BrowserNavigationGuard />
       <NavigationModal />
       <div
-        className={`before:bg-patternImg relative flex min-h-screen flex-col justify-start bg-gradient-to-b from-violet-950 via-violet-800 to-fuchsia-800 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:bg-cover before:bg-center lg:py-5`}
+        className={`relative flex min-h-screen flex-col justify-start bg-gradient-to-b from-violet-950 via-violet-800 to-fuchsia-800 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:bg-patternImg before:bg-cover before:bg-center lg:py-5`}
       >
         {/* 상단 헤더 */}
         <GameHeader />

--- a/client/src/pages/ResultPage.tsx
+++ b/client/src/pages/ResultPage.tsx
@@ -21,11 +21,12 @@ const ResultPage = () => {
       terminateType === TerminationType.PLAYER_DISCONNECT
         ? '나간 플레이어가 있어요. 20초 후 대기실로 이동합니다!'
         : '20초 후 대기실로 이동합니다!';
+    const variant = terminateType === TerminationType.PLAYER_DISCONNECT ? 'warning' : 'success';
 
     toastActions.addToast({
       title: '게임 종료',
       description,
-      variant: 'success',
+      variant,
       duration: 20000,
     });
   }, [terminateType, toastActions]);


### PR DESCRIPTION
## 📂 작업 내용

closes #179 

- [x]  라운드 3,5,7,9,11
- [x]  설정 변경 시 infinite error 해결 

## 💡 자세한 설명

### 설정 무한 리렌더링 수정
- 기존 코드에서 roomSetting과 selectedValue 사이에서 무한으로 리렌더링되는 이슈가 있어 해결하였습니다.

### 라운드 
- 기존 3, 5 라운드에서 3, 5, 7, 9, 11 라운드 까지 늘려주었습니다.

### 기타 UI 핸들링
- 라운드 결과 모달에서도 타이머를 띄웠습니다.
- 게임 상태에 따라 적절한 문구를 띄우도록 했습니다. 구경꾼이 맞출 때 그림꾼과 방해꾼에게는 `제시어 (맞히는중...)` 이 뜨도록 하였고, 구경꾼에게는 `맞혀보세요-!` 가 뜨도록 하였습니다. 또한 구경꾼이 그림 그리는 것을 기다릴 때 `화가들이 실력을 뽐내는중...` 를 띄우도록 했습니다. 


## 📗 참고 자료 & 구현 결과 (선택)

- 구경꾼들이 정답을 맞힐 때 그림꾼과 방해꾼들에게는 `제시어 (맞히는중...)` 을 띄워줍니다
<img width="1406" alt="image" src="https://github.com/user-attachments/assets/041bb059-d53e-4730-b30a-adf33665e6c5">

- 구경꾼들이 정답을 맞힐 때 구경꾼들에게는 `맞혀보세요-!`를 띄워줍니다.
<img width="1406" alt="image" src="https://github.com/user-attachments/assets/16cf52d5-030a-47a6-a3fc-bbc1229e51e6">

- 구경꾼들이 그림을 기다릴 때 `화가들이 실력을 뽐내는중...`을 띄워줍니다. 
<img width="1427" alt="image" src="https://github.com/user-attachments/assets/d9fd74fd-7f77-430a-bfcb-156b2306ac79">

- 라운드 종료 모달 카운트 다운을 띄워줍니다. 중요한 정보가 아니라고 생각되어 옅은 색으로 띄웠습니다. 
<img width="1409" alt="image" src="https://github.com/user-attachments/assets/6e19b95c-64b6-4df0-ab63-6f76372ecb46">


## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
